### PR TITLE
Package initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # klax
-Collection of semi-common machine learning architectures and tools build on JAX + Equinox
+Collection of semi-common machine learning architectures and tools build on JAX + Equinox + Paramax

--- a/klax/__init__.py
+++ b/klax/__init__.py
@@ -1,0 +1,1 @@
+from . import nn as nn

--- a/klax/_misc.py
+++ b/klax/_misc.py
@@ -1,0 +1,10 @@
+import jax
+import jax.numpy as jnp
+
+
+def default_floating_dtype():
+    """This function was copied from equinox._misc"""
+    if jax.config.jax_enable_x64:
+        return jnp.float64
+    else:
+        return jnp.float32

--- a/klax/nn/__init__.py
+++ b/klax/nn/__init__.py
@@ -1,0 +1,1 @@
+from ._linear import Linear as Linear

--- a/klax/nn/_linear.py
+++ b/klax/nn/_linear.py
@@ -1,0 +1,109 @@
+from typing import (
+    Literal,
+    Optional,
+    Union,
+)
+
+import equinox as eqx
+from jax.nn.initializers import Initializer, zeros
+import jax.numpy as jnp
+import jax.random as jrandom
+from jaxtyping import Array, PRNGKeyArray
+
+from .._misc import default_floating_dtype
+
+
+class Linear(eqx.Module, strict=True):
+    """Performs a linear transformation.
+
+    Modified from eqx.nn.Linear to allow for custom parameter initialization,
+    similar to flax.nnx.nn.Linear. This also means that there is no limit to
+    the initialized parameters as in eqx.nn.Linear. Instead, it is the users
+    job to define the limits in the initializer that is passed to __init__().
+    """
+
+    weight: Array
+    bias: Optional[Array]
+    in_features: Union[int, Literal["scalar"]] = eqx.field(static=True)
+    out_features: Union[int, Literal["scalar"]] = eqx.field(static=True)
+    use_bias: bool = eqx.field(static=True)
+
+    def __init__(
+        self,
+        in_features: Union[int, Literal["scalar"]],
+        out_features: Union[int, Literal["scalar"]],
+        weight_init: Initializer,
+        bias_init: Initializer = zeros,
+        use_bias: bool = True,
+        dtype=None,
+        *,
+        key: PRNGKeyArray,
+    ):
+        """**Arguments:**
+
+        - `in_features`: The input size. The input to the layer should be a vector of
+            shape `(in_features,)`
+        - `out_features`: The output size. The output from the layer will be a vector
+            of shape `(out_features,)`.
+        - `use_bias`: Whether to add on a bias as well.
+        - `dtype`: The dtype to use for the weight and the bias in this layer.
+            Defaults to either `jax.numpy.float32` or `jax.numpy.float64` depending
+            on whether JAX is in 64-bit mode.
+        - `key`: A `jax.random.PRNGKey` used to provide randomness for parameter
+            initialisation. (Keyword only argument.)
+
+        Note that `in_features` also supports the string `"scalar"` as a special value.
+        In this case the input to the layer should be of shape `()`.
+
+        Likewise `out_features` can also be a string `"scalar"`, in which case the
+        output from the layer will have shape `()`.
+        """
+        dtype = default_floating_dtype() if dtype is None else dtype
+        wkey, bkey = jrandom.split(key, 2)
+        in_features_ = 1 if in_features == "scalar" else in_features
+        out_features_ = 1 if out_features == "scalar" else out_features
+        wshape = (out_features_, in_features_)
+        self.weight = weight_init(wkey, wshape, dtype)
+        bshape = (out_features_,)
+        self.bias = bias_init(bkey, bshape, dtype) if use_bias else None
+
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_bias = use_bias
+
+    def __call__(self, x: Array, *, key: Optional[PRNGKeyArray] = None) -> Array:
+        """**Arguments:**
+
+        - `x`: The input. Should be a JAX array of shape `(in_features,)`. (Or shape
+            `()` if `in_features="scalar"`.)
+        - `key`: Ignored; provided for compatibility with the rest of the Equinox API.
+            (Keyword only argument.)
+
+        !!! info
+
+            If you want to use higher order tensors as inputs (for example featuring "
+            "batch dimensions) then use `jax.vmap`. For example, for an input `x` of "
+            "shape `(batch, in_features)`, using
+            ```python
+            linear = equinox.nn.Linear(...)
+            jax.vmap(linear)(x)
+            ```
+            will produce the appropriate output of shape `(batch, out_features)`.
+
+        **Returns:**
+
+        A JAX array of shape `(out_features,)`. (Or shape `()` if
+        `out_features="scalar"`.)
+        """
+
+        if self.in_features == "scalar":
+            if jnp.shape(x) != ():
+                raise ValueError("x must have scalar shape")
+            x = jnp.broadcast_to(x, (1,))
+        x = self.weight @ x
+        if self.bias is not None:
+            x = x + self.bias
+        if self.out_features == "scalar":
+            assert jnp.shape(x) == (1,)
+            x = jnp.squeeze(x)
+        return x

--- a/klax/nn/_linear.py
+++ b/klax/nn/_linear.py
@@ -16,10 +16,7 @@ from .._misc import default_floating_dtype
 class Linear(eqx.Module, strict=True):
     """Performs a linear transformation.
 
-    Modified from eqx.nn.Linear to allow for custom parameter initialization,
-    similar to flax.nnx.nn.Linear. This also means that there is no limit to
-    the initialized parameters as in eqx.nn.Linear. Instead, it is the users
-    job to define the limits in the initializer that is passed to __init__().
+    This class is modified from eqx.nn.Linear to allow for custom initialization.
     """
 
     weight: Array
@@ -45,6 +42,8 @@ class Linear(eqx.Module, strict=True):
             shape `(in_features,)`
         - `out_features`: The output size. The output from the layer will be a vector
             of shape `(out_features,)`.
+        - `weight_init`: The weight initializer of type `jax.nn.initializers.Initializer`.
+        - `bias_init`: The bias initializer of type `jax.nn.initializers.Initializer`.
         - `use_bias`: Whether to add on a bias as well.
         - `dtype`: The dtype to use for the weight and the bias in this layer.
             Defaults to either `jax.numpy.float32` or `jax.numpy.float64` depending
@@ -57,6 +56,12 @@ class Linear(eqx.Module, strict=True):
 
         Likewise `out_features` can also be a string `"scalar"`, in which case the
         output from the layer will have shape `()`.
+
+        Further note that, some `jax.nn.initializers.Initializer`s do not work if
+        one of `in_features` or `out_features` is zero.
+
+        Likewise, some `jax.nn.initializers.Initialzers`s do not work when `dtype` is
+        `jax.numpy.complex64`.
         """
         dtype = default_floating_dtype() if dtype is None else dtype
         wkey, bkey = jrandom.split(key, 2)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,35 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "klax"
+version = "0.0.1"
+description = "Collection of semi-common machine learning architectures and tools build on JAX + Equinox + Paramax"
+authors = [
+    { name = "Fabian Roth", email = "some@email.com" },
+    { name = "Jasper Schommartz", email = "some@email.com" },
+]
+maintainers = [
+    { name = "Fabian Roth", email = "some@email.com" },
+    { name = "Jasper Schommartz", email = "some@email.com" },
+]
+readme = "README.md"
+requires-python = ">=3.11"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Operating System :: OS Independent"
+]
+dependencies = ["jax", "equinox", "paramax"]
+
+[project.optional-dependencies]
+testing = [
+    "pytest"
+]
+
+[tool.setuptools.packages.find]
+where = ["klax"]
+
+[project.urls]
+Repository = "https://github.com/Drenderer/klax"
+Issues = "https://github.com/jaosch/feap-caller/klax"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,20 @@
+import typing
+
+import jax
+import pytest
+
+
+typing.TESTING = True  # pyright: ignore
+
+
+jax.config.update("jax_numpy_dtype_promotion", "strict")
+jax.config.update("jax_numpy_rank_promotion", "raise")
+
+
+@pytest.fixture
+def getkey():
+    # Delayed import so that jaxtyping can transform the AST of Equinox before it is
+    # imported, but conftest.py is ran before then.
+    import equinox.internal as eqxi
+
+    return eqxi.GetKey()

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -1,0 +1,70 @@
+from jax.nn.initializers import uniform, he_normal
+import jax.numpy as jnp
+import jax.random as jrandom
+import klax
+import pytest
+
+
+def test_linear(getkey):
+    # Zero input shape
+    linear = klax.nn.Linear(0, 4, uniform(), key=getkey())
+    x = jrandom.normal(getkey(), (0,))
+    assert linear(x).shape == (4,)
+
+    # Zero output shape
+    linear = klax.nn.Linear(4, 0, uniform(), key=getkey())
+    x = jrandom.normal(getkey(), (4,))
+    assert linear(x).shape == (0,)
+
+    # Positional arguments
+    linear = klax.nn.Linear(3, 4, uniform(), key=getkey())
+    x = jrandom.normal(getkey(), (3,))
+    assert linear(x).shape == (4,)
+
+    # Some keyword arguments
+    linear = klax.nn.Linear(
+        3,
+        out_features=4,
+        weight_init=uniform(),
+        key=getkey()
+    )
+    x = jrandom.normal(getkey(), (3,))
+    assert linear(x).shape == (4,)
+
+    # All keyword arguments
+    linear = klax.nn.Linear(
+        in_features=3,
+        out_features=4,
+        weight_init=uniform(),
+        key=getkey()
+    )
+    x = jrandom.normal(getkey(), (3,))
+    assert linear(x).shape == (4,)
+
+    linear = klax.nn.Linear("scalar", 2, uniform(), key=getkey())
+    x = jrandom.normal(getkey(), ())
+    assert linear(x).shape == (2,)
+
+    linear = klax.nn.Linear(2, "scalar", uniform(), key=getkey())
+    x = jrandom.normal(getkey(), (2,))
+    assert linear(x).shape == ()
+
+    linear = klax.nn.Linear(
+        2,
+        "scalar",
+        uniform(),
+        key=getkey(),
+        dtype=jnp.float16
+    )
+    x = jrandom.normal(getkey(), (2,), dtype=jnp.float16)
+    assert linear(x).dtype == jnp.float16
+
+    linear = klax.nn.Linear(
+        2,
+        "scalar",
+        he_normal(), # since uniform does not acces complex numbers
+        key=getkey(),
+        dtype=jnp.complex64
+    )
+    x = jrandom.normal(getkey(), (2,), dtype=jnp.complex64)
+    assert linear(x).dtype == jnp.complex64


### PR DESCRIPTION
An custom implementation of equinox.nn.Linear is provided that enables custom parameter initialization. While the bias is initialized to zero by default, the weights inititialization must always be provided by the user, because not every initialization works with every data type and every input shape. For example, He normal initialization does not accept shapes that are zero, while uniform initialization does not work with complex numbers.

A test for the klax.nn.Linear is implemented, which is closely related to the tests implemented in equinox.