### PR TITLE
Data loader for abitrary `PyTree`s

### DIFF
--- a/klax/_training.py
+++ b/klax/_training.py
@@ -2,7 +2,7 @@
 This module implements a basic training loop.
 """
 
-from typing import Generator, Sequence
+from typing import Generator
 
 import equinox as eqx
 import jax
@@ -13,29 +13,29 @@ import numpy as np
 
 
 def dataloader(
-    data: Sequence[ArrayLike],
+    data: PyTree[ArrayLike],
     batch_size: int = 32,
-    batch_mask: Sequence[bool] | None = None,
+    batch_mask: PyTree[bool] | None = None,
     *,
     key:PRNGKeyArray,
-) -> Generator[PyTree, None, None]:
+) -> Generator[PyTree[ArrayLike], None, None]:
     """Returns a batch `Generator` that yields randomly chosen subsets of data
     without replacement.
 
-    The data may be an any `Sequence` of `ArrayLike`. If `batch_mask` is passed, elements
-    without batch dimension can be specified.    
+    The data can be any `PyTree` with `ArrayLike` leaves. If `batch_mask` is passed,
+    leaves without batch dimension can be specified.    
 
     !!! example
 
-        This is an example for a nested `Sequence`, where the elements x and y
+        This is an example for a nested `PyTree`, where the elements x and y
         have batch dimension along the first axis.
     
         ```python
 
             x = jnp.array([1., 2.])
             y = jnp.array([[1.], [2.]])
-            data = (x, (1.0, y))
-            batch_mask = (True, (False, True))
+            data = (x, {"a": 1.0, "b": y))
+            batch_mask = (True, {"a": False, "b": True})
             iter_data = dataloader(
                 data,
                 32,
@@ -46,19 +46,20 @@ def dataloader(
 
     **Arguments:**
 
-     - `data`: The `Sequence` of `ArrayLike` data that shall be batched. 
+     - `data`: The data that shall be batched. It can be any `PyTree` with `ArrayLike`
+         leaves. 
      - `batch_size`: The number of examples in a batch.
-     - `batch_mask`: The sequence denoting, which elements of `data` have batch
-        dimension. `batch_mask` must have the same `Sequence`structure as `data`, where
-         the elements are replaced with values of type `bool`. `True` indicates
-         that the corresponding element in `data` has batch dimension. If `False`, the
-         corresponding element will be returned unchanged by the `Generator`.
-         (Defaults to `None`, meaning all elements of `data` have batch dimension.)
+     - `batch_mask`: The `PyTree` denoting, which leaves of `data` have batch
+        dimension. `batch_mask` must have the same structure as `data`, where
+         the leaves are replaced with values of type `bool`. `True` indicates
+         that the corresponding leaf in `data` has batch dimension. If `False`, the
+         corresponding leaf will be returned unchanged by the `Generator`.
+         (Defaults to `None`, meaning all leaves in `data` have batch dimension.)
      - `key`: A `jax.random.PRNGKey` used to provide randomness for batch generation.
          (Keyword only argument.)
 
-    Note that the batch dimension for all batched elements must correspond to the first
-    array dimension.
+    Note that the batch axis for all batched leaves must correspond to the first
+    array axis.
 
     **Returns:**
 
@@ -66,28 +67,32 @@ def dataloader(
 
     **Yields:**
     
-    A `Sequence[ArrayLike]` with the same structure as data. Where the non-masked
-    leafs have a size of `batch_size`.
+    A `PyTree[ArrayLike]` with the same structure as `data`. Where all batched
+    leaves have `batch_size`.
+
+    Note that if the size of the dataset is smaller than `batch_size`, the obtained
+    batches will have dataset size.
     """
 
     # Generate an all true batch mask if batch_mask = None was passed
     if batch_mask is None:
         batch_mask = jax.tree.map(lambda x: x is not None, data)
-    print(batch_mask)
-
+    
+    # Check that data and batch_mask have the same PyTree structure
+    if jax.tree.structure(data) != jax.tree.structure(batch_mask):
+        raise ValueError(
+            "Arguments data and batch_mask must have equal PyTree structures.")
+    
     # Split the PyTree according to the batch mask
     batched_data, unbatched_data = eqx.partition(data, batch_mask)
 
-    # Check that all batched data has the same batch dimension along their
-    # respective batch axes
+    # Check that all batched leaves has the same dimension along the first axis
     batched_leafs = jax.tree.leaves(batched_data)
     if len(batched_leafs) == 0:
-        raise ValueError("At least one element must have a batch dimension.")
+        raise ValueError("At least one element must have batch dimension.")
     dataset_size = batched_leafs[0].shape[0]
-    for arr in batched_leafs[1:]:
-        print(arr.shape[0])
     if not all(arr.shape[0] == dataset_size for arr in batched_leafs[1:]):
-        raise ValueError("All batched arrays must have the same batch dimension.")
+        raise ValueError("All batched arrays must have equal batch dimension.")
 
     # Convert to Numpy arrays. Numpy's slicing is much faster than Jax's, so for
     # fast model training steps this actually makes a huge difference!

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -9,14 +9,19 @@ def test_dataloader(getkey):
     x = jrandom.uniform(getkey(), (10,))
     data = (x,)
     generator = klax.dataloader(data, key=getkey()) 
+    assert isinstance(next(generator), tuple)
     assert len(next(generator)) == 1
 
-    # Nested sequence
+    # Nested PyTree
     x = jrandom.uniform(getkey(), (10,))
-    data = (x, (x, x))
+    data = [x, (x, {"a": x, "b": x})]
     generator = klax.dataloader(data, key=getkey()) 
+    assert isinstance(next(generator), list)
     assert len(next(generator)) == 2
+    assert isinstance(next(generator)[1], tuple)
     assert len(next(generator)[1]) == 2
+    assert isinstance(next(generator)[1][1], dict)
+    assert len(next(generator)[1][1]) == 2
 
     # Default batch size
     x = jrandom.uniform(getkey(), (33,))
@@ -33,11 +38,25 @@ def test_dataloader(getkey):
     assert next(generator)[1][0].shape[0] == 10
     assert next(generator)[1][1].shape[0] == 2
 
+    # Different PyTree structures
+    x = jrandom.uniform(getkey(), (10,))
+    data = (x, x)
+    batch_mask = (True, )
+    with pytest.raises(
+        ValueError,
+        match="Arguments data and batch_mask must have equal PyTree structures."
+    ):
+        generator = klax.dataloader(data, batch_mask=batch_mask, key=getkey())
+        next(generator)
+
     # No batch dimensions
     x = jrandom.uniform(getkey(), (10,))
     data = (x,)
     batch_mask = (False,)
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError,
+        match="At least one element must have batch dimension."
+    ):
         generator = klax.dataloader(data, batch_mask=batch_mask, key=getkey()) 
         next(generator)
 
@@ -45,6 +64,9 @@ def test_dataloader(getkey):
     x = jrandom.uniform(getkey(), (10,))
     y = jrandom.uniform(getkey(), (5,))
     data = (x, y)
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError,
+        match="All batched arrays must have equal batch dimension."
+    ):
         generator = klax.dataloader(data, key=getkey()) 
         next(generator)


### PR DESCRIPTION
Type annotations where changed from `Sequence` to `PyTree`, because the data loader works for any `PyTree` data structure. To show this, a test with a complex nested, data structure as added.

To make sure that the `data` and `batch_mask` arguments always have identical `PyTree` structure, an additional assert was added and tested.

Some reformulations.