### PR TITLE
Fixed type annotations + typing module

### DIFF
--- a/klax/__init__.py
+++ b/klax/__init__.py
@@ -1,2 +1,2 @@
-from . import nn as nn, wrappers as wrappers
+from . import nn as nn, typing as typing, wrappers as wrappers
 from ._training import dataloader as dataloader, fit as fit

--- a/klax/typing.py
+++ b/klax/typing.py
@@ -1,0 +1,35 @@
+"""A collection of useful type aliases used within klax."""
+import typing
+from typing import Any, Generator, Protocol, Sequence, TypeAlias
+
+from jaxtyping import Array, ArrayLike, PRNGKeyArray, PyTree
+
+
+MaskTree: TypeAlias = PyTree[bool]
+DataTree: TypeAlias = PyTree[ArrayLike | None]
+
+BatchGenerator: TypeAlias = Generator[DataTree, None, None]
+
+@typing.runtime_checkable
+class Dataloader(Protocol):
+    def __call__(
+        self,
+        data: DataTree,
+        batch_size: int,
+        batch_mask: MaskTree | None,
+        *,
+        key: PRNGKeyArray
+    ) -> BatchGenerator:
+        raise NotImplementedError
+
+
+@typing.runtime_checkable
+class Loss(Protocol):
+    def __call__(
+        self,
+        model: PyTree,
+        x: DataTree,
+        y: DataTree,
+        in_axes: int | None | Sequence[Any] = 0
+    ) -> Array:
+        raise NotImplementedError


### PR DESCRIPTION
All TypeAliases were moved to a new `klax.typing` module.  To create emplates for dataloaders and loss functions, protocols were created.

All type errors in the `test_training.py` are now resolved and all but one are resolved in `_training.py`. The remainig one has to do with the history.