### PR TITLE
Changed klax.fit training data argument to a single Pytree.

### DIFF
--- a/klax/_training.py
+++ b/klax/_training.py
@@ -154,13 +154,11 @@ def dataloader(
 
 
 def fit(model: T,
-        x: DataTree,
-        y: DataTree,
-        batch_size: int = 32,
-        in_mask: Optional[MaskTree] = None,
-        out_mask: Optional[MaskTree] = None,
+        training_data: DataTree,
         *,
-        validation_data: Optional[Tuple[DataTree, DataTree]] = None,
+        batch_size: int = 32,
+        data_mask: Optional[MaskTree] = None,
+        validation_data: Optional[DataTree] = None,
         steps: int = 1000,
         log_every: int = 100,
         loss_fn: Loss = mse,
@@ -176,22 +174,18 @@ def fit(model: T,
 
     - `model`: The model instance, which should be trained. It must be a subclass of
         `eqx.Module`. The model may contain `paramax.AbstractUnwrappable` wrappers.
-    - `x`: The input data. It can be any `PyTree` with `ArrayLike` leaves.
-    - `y`: The target data. It can be any `PyTree` with `ArrayLike` leaves.
+    - `training_data`: The training data can be any `PyTree` with `ArrayLike` leaves.
+        Most likely you'll want `training_data` to be a tuple `(x, y)` with model inputs \
+        `x` and model outputs `y`.
     - `batch_size`: The number of examples in a batch.
-    - `in_mask`: The `PyTree` denoting, which leaves of `x` have batch
-        dimension. `in_mask` must have the same structure as `x`, where
-        the leaves are replaced with values of type `bool`. `True` indicates
-        that the corresponding leaf in `x` has batch dimension. If `False`, the
+    - `data_mask`: The `PyTree` denoting, which leaves of `training_data` have batch \
+        dimension. `data_mask` must have the same structure as `training_data`, where \
+        the leaves are replaced with values of type `bool`. `True` indicates \
+        that the corresponding leaf in `training_data` has batch dimension. If `False`, the \
         corresponding leaf will be returned unchanged by the `Generator`.
-        (Defaults to `None`, meaning all leaves in `x` have batch dimension.)
-    - `out_mask`: The `PyTree` denoting, which leaves of `y` have batch
-        dimension. `out_mask` must have the same structure as `y`, where
-        the leaves are replaced with values of type `bool`. `True` indicates
-        that the corresponding leaf in `y` has batch dimension. If `False`, the
-        corresponding leaf will be returned unchanged by the `Generator`.
-        (Defaults to `None`, meaning all leaves in `y` have batch dimension.)
-    - `validation_data`: A tuple of inputs and targets used for validation during training.
+        (Defaults to `None`, meaning all leaves in `training_data` have batch dimension.)
+    - `validation_data`: Arbitrary `PyTree` used for validation during training. \
+        Must have the same tree structure as `training_data`.
         (Defaults to None. Keyword only argument)
     - `steps`: Number of gradient updates to apply. (Defaults to 1000. Keyword only argument)
     - `log_every`: The number of steps between updates of the loss history. A history update
@@ -203,8 +197,8 @@ def fit(model: T,
         the model. (Defaults to optax.adam(1e-3).)
     - `dataloader`: The data loader that splits inputs and targets into batches.
         (Defaults to `dataloader`)
-    - `callbacks`: Callback functions that are evaluated after every training step. They can
-        be used to implement early stopping, custom history logging and more. The argument to the 
+    - `callbacks`: Callback functions that are evaluated after every training step. They can \
+        be used to implement early stopping, custom history logging and more. The argument to the \
         callback function is a CallbackArgs object. (Defaults to `None`. Keyword only Argument)
     - `key`: A `jax.random.PRNGKey` used to provide randomness for batch generation.
         (Keyword only argument.)
@@ -217,43 +211,37 @@ def fit(model: T,
     Returns a tuple of the trained model and a history dictionary containing the loss history.
     """
 
-    # Generate an all true masks if in_axes/out_axes is None
-    if in_mask is None:
-        in_mask = jax.tree.map(lambda x: x is not None, x)
-    if out_mask is None:
-        out_mask = jax.tree.map(lambda x: x is not None, y)
+    # Generate an all true masks if data_mask is None
+    if data_mask is None:
+        data_mask = jax.tree.map(lambda x: x is not None, training_data)
 
-    # Check that y and x have the same PyTree structure as in_mask and out_mask
-    if jax.tree.structure(x) != jax.tree.structure(in_mask):
-        raise ValueError(
-            "Arguments x and in_mask must have equal PyTree structure.")
-    if jax.tree.structure(y) != jax.tree.structure(out_mask):
-        raise ValueError(
-            "Arguments y and in_mask must have equal PyTree structure.")
+    # Check that training_data has the same PyTree structure as data_mask
+    if jax.tree.structure(training_data) != jax.tree.structure(data_mask):
+        raise ValueError("Arguments training_data and data_mask must have equal PyTree structure.")
 
     # Mark the first dimension as batch dimension for all leaves in x that are
     # not masked
-    in_axes = jax.tree.map(lambda x: 0 if x else None, in_mask)
+    batch_axis = jax.tree.map(lambda x: 0 if x else None, data_mask)
 
     # Define a function to calculate the loss. This is jit compiled to speed up
     # the loss evaluation for the loss history.
     @eqx.filter_jit
-    def get_loss(model, x, y):
+    def get_loss(model, batch):
         model = px.unwrap(model)
-        return loss_fn(model, x, y, in_axes=in_axes)
+        return loss_fn(model, batch, batch_axis=batch_axis)
 
     # Get the gradient function
     grad_loss = eqx.filter_grad(get_loss)
 
     @eqx.filter_jit
-    def make_step(x, y, flat_model, optimizer, flat_opt_state):
+    def make_step(batch, flat_model, optimizer, flat_opt_state):
         # Use the unflatten trick to speed up training,
         # see https://docs.kidger.site/equinox/tricks/
         model = jax.tree_util.tree_unflatten(treedef_model, flat_model)
         opt_state = jax.tree_util.tree_unflatten(treedef_opt_state, flat_opt_state)
 
         # Compute and apply the parameter updates
-        grads = grad_loss(model, x, y)
+        grads = grad_loss(model, batch)
         updates, opt_state = optimizer.update(
             grads,
             opt_state,
@@ -268,9 +256,7 @@ def fit(model: T,
 
     # Initialize the history dict
     history = {'steps': [], 'loss': [],}
-    vx, vy = None, None
     if validation_data is not None:
-        vx, vy = validation_data
         history['val_loss'] = []
 
     val_loss = None
@@ -285,20 +271,19 @@ def fit(model: T,
     flat_opt_state, treedef_opt_state = jax.tree_util.tree_flatten(opt_state)
 
 
-    cbargs = CallbackArgs(get_loss, (x, y), validation_data, treedef_model)
+    cbargs = CallbackArgs(get_loss, training_data, validation_data, treedef_model)
 
 
     # Loop over all training steps
     start_time = time.time()
-    for step, (xi, yi) in zip(range(1, steps+1), dataloader(
-        (x, y),
+    for step, batch in zip(range(1, steps+1), dataloader(
+        training_data,
         batch_size,
-        (in_mask, out_mask),
+        data_mask,  #TODO: Give batch_axis to the dataloader instead and allow for custom batch axis for every pytree leaf
         key=key
     )):
         flat_model, flat_opt_state = make_step(
-            xi,
-            yi,
+            batch,
             flat_model,
             optimizer,
             flat_opt_state

--- a/klax/losses.py
+++ b/klax/losses.py
@@ -27,7 +27,7 @@ def expects_tuple_and_vmap(loss: Callable[[Array, Array], Scalar]):
 
     **Arguments:**
         `loss`: Loss function taking the output prediction and
-        ground truth as intput.
+        ground truth as input.
     """
     def new_loss(
         model: PyTree,
@@ -36,7 +36,7 @@ def expects_tuple_and_vmap(loss: Callable[[Array, Array], Scalar]):
     ) -> Scalar:
         x, y = data
         in_axes, _ = batch_axis
-        y_pred = jax.vmap(model, in_axes=in_axes)(x)
+        y_pred = jax.vmap(model, in_axes=(in_axes,))(x)
         return loss(y_pred, y)
     return new_loss
 

--- a/klax/losses.py
+++ b/klax/losses.py
@@ -1,9 +1,9 @@
 import typing
-from typing import Any, Protocol, Sequence
+from typing import Any, Callable, Protocol, Sequence
 
 import jax
 import jax.numpy as jnp
-from jaxtyping import PyTree, Scalar
+from jaxtyping import PyTree, Scalar, Array
 
 from .typing import DataTree
 
@@ -13,28 +13,37 @@ class Loss(Protocol):
     def __call__(
         self,
         model: PyTree,
-        x: DataTree,
-        y: DataTree,
-        in_axes: int | None | Sequence[Any]
+        data: DataTree,
+        batch_axis: int | None | Sequence[Any]
     ) -> Scalar:
         raise NotImplementedError
 
 
-def mse(
-    model: PyTree,
-    x: DataTree,
-    y: DataTree,
-    in_axes: int | None | Sequence[Any] = 0
-) -> Scalar:
-    y_pred = jax.vmap(model, in_axes=in_axes)(x)
-    return jnp.mean((y_pred - y) ** 2)
+def expects_tuple_and_vmap(loss: Callable[[Array, Array], Scalar]):
+    """
+    Wrapper for loss functions that splits the data into two,
+    vmaps the model and then passes the output prediction and 
+    the ground truth output to the wrapped function.
 
+    **Arguments:**
+        `loss`: Loss function taking the output prediction and
+        ground truth as intput.
+    """
+    def new_loss(
+        model: PyTree,
+        data: DataTree,
+        batch_axis: int | None | Sequence[Any] = 0
+    ) -> Scalar:
+        x, y = data
+        in_axes, _ = batch_axis
+        y_pred = jax.vmap(model, in_axes=in_axes)(x)
+        return loss(y_pred, y)
+    return new_loss
 
-def mae(
-    model: PyTree,
-    x: DataTree,
-    y: DataTree,
-    in_axes: int | None | Sequence[Any] = 0
-) -> Scalar:
-    y_pred = jax.vmap(model, in_axes=in_axes)(x)
+@expects_tuple_and_vmap
+def mse(y_pred, y):
+    return jnp.mean(jnp.square(y_pred - y))
+
+@expects_tuple_and_vmap
+def mae(y_pred, y):
     return jnp.mean(jnp.abs(y_pred - y))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,14 +38,3 @@ def getwrap():
             return jnp.zeros_like(self.parameter)
     
     return Wrapper
-
-
-@pytest.fixture
-def getcallback():
-    import klax
-
-    def callback(cbargs: klax.callbacks.CallbackArgs):
-        if cbargs.step == 123:
-            return True
-
-    return callback

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -7,7 +7,8 @@ from klax.callbacks import CallbackArgs
 def test_callbackargs():
 
     computation_counter = 0
-    def get_loss(model, x, y):
+    def get_loss(model, data):
+        x, y = data
         nonlocal computation_counter
         computation_counter += 1
         y_pred = jax.vmap(model)(x)

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -77,15 +77,14 @@ def test_dataloader(getkey):
         next(generator)
 
 
-def test_training(getkey, getcallback):
+def test_training(getkey):
     # Fitting a linear function
     x = jnp.linspace(0.0, 1.0, 2).reshape(-1, 1)
     y = 2.* x + 1.0
     model = eqx.nn.Linear(1, 1, key=getkey())
     model, _ = klax.fit(
         model,
-        x,
-        y,
+        (x, y),
         optimizer=optax.adam(1.0),
         key=getkey())
     y_pred = jax.vmap(model)(x)
@@ -94,7 +93,7 @@ def test_training(getkey, getcallback):
     # History shape and type
     x = jrandom.uniform(getkey(), (2, 1))
     model = eqx.nn.Linear(1, 1, key=getkey())
-    _, history = klax.fit(model, x, x, key=getkey())
+    _, history = klax.fit(model, (x, x), key=getkey())
     assert all(isinstance(x, np.ndarray) for _, x in history.items())
     assert history["steps"].shape == (10,)
     assert history["loss"].shape == (10,)
@@ -103,19 +102,23 @@ def test_training(getkey, getcallback):
     # Validation data
     x = jrandom.uniform(getkey(), (2, 1))
     model = eqx.nn.Linear(1, 1, key=getkey())
-    _, history = klax.fit(model, x, x, validation_data=(x, x), key=getkey())
+    _, history = klax.fit(model, (x, x), validation_data=(x, x), key=getkey())
     assert isinstance(history["val_loss"], np.ndarray)
     assert history["val_loss"].shape == (10,)
 
     # Callbacks
     x = jrandom.uniform(getkey(), (2, 1))
     model = eqx.nn.Linear(1, 1, key=getkey())
+
+    def callback(cbargs: klax.callbacks.CallbackArgs):
+        if cbargs.step == 123:
+            return True
+        
     _, history = klax.fit(
         model,
-        x,
-        x,
+        (x, x),
         log_every=1,
-        callbacks=[getcallback],
+        callbacks=[callback],
         key=getkey()
     )
     assert history['steps'][-1] == 123


### PR DESCRIPTION
Changed klax.fit training data argument from model input and output to a single Pytree for the entire training data.

Changed losses accordingly.  Added wrapper for easy creation of simple losses. Callbackargs now explicitly have training and test data available as attributes. Test were modified accordingly.