### PR TITLE
Fix the gitignore issue that was not entirely fixed in the last feature/docs merge.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,7 +74,7 @@ instance/
 # Sphinx documentation
 docs/_build/
 docs/build/
-docs/_autosummary/
+docs/source/_autosummary/
 
 # PyBuilder
 .pybuilder/


### PR DESCRIPTION
This commit is the reaction to a recent issue #34. Changed gitignore from `docs/_autosummary/` to `docs/source/_autosummary`.