### PR TITLE
Introduce apply functionality for ParameterWrappers

### DIFF
--- a/klax/__init__.py
+++ b/klax/__init__.py
@@ -3,4 +3,8 @@ from ._callbacks import Callback, CallbackArgs, HistoryCallback
 from ._datahandler import batch_data, BatchGenerator, split_data
 from ._losses import Loss, mse, mae
 from ._training import fit as fit
-from ._wrappers import ParameterWrapper, NonNegative
+from ._wrappers import (
+    apply as apply,
+    ParameterWrapper as ParameterWrapper,
+    NonNegative as NonNegative
+)

--- a/klax/_wrappers.py
+++ b/klax/_wrappers.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 from abc import abstractmethod
+from typing import Self
 
+import jax
 import jax.numpy as jnp
-from jaxtyping import Array
+from jaxtyping import Array, PyTree
 import paramax as px
 
 
@@ -14,14 +16,20 @@ unwrap = px.unwrap
 class ParameterWrapper(px.AbstractUnwrappable[Array]):
     """An abstract class representing parameter wrappers.
 
-    ParameterWrappers replace PyTree leafs, applying custom behaviour upon
-    unwrapping"""
+    ``ParameterWrappers`` are a specialized version of ``paramax.AbstractUnwrappable``
+    that returns an updated version of itself upon applying. ``ParameterWrappers``
+    cannot be nested but are fully compatible with paramax's unwrapping functionality.
+    """
 
-    def __init__(self, parameter: Array | px.AbstractUnwrappable[Array]):
+    def __init__(self, parameter: Array):
         raise NotImplementedError("To be implemented by derived classes")
 
     @abstractmethod
     def unwrap(self) -> Array:
+        pass
+
+    @abstractmethod
+    def apply(self) -> Self:
         pass
 
 
@@ -29,19 +37,56 @@ class NonNegative(ParameterWrapper):
     """Applies a non-negative constraint.
 
     Args:
-        parameter: The parameter that is to be made non-negative. It can either
-            be a `jax.Array` or a `paramax.AbstractUnwrappable`that is wrapped
-            around a `jax.Array`.
+        parameter: The ``jax.Array`` that is to be made non-negative upon unwrapping
+            and applying.
     """
 
     parameter: Array
 
-    def __init__(self, parameter: Array | px.AbstractUnwrappable[Array]):
+    def __init__(self, parameter: Array):
         # Ensure that the parameter fulfills the constraint initially
-        self.parameter = self._non_neg(px.unwrap(parameter))
+        self.parameter = self._non_neg(parameter)
 
     def _non_neg(self, x: Array) -> Array:
         return jnp.maximum(x, 0)
 
     def unwrap(self) -> Array:
         return self._non_neg(self.parameter)
+
+    def apply(self) -> Array:
+        return NonNegative(self._non_neg(self.parameter))
+
+
+def apply(tree: PyTree):
+    """Map across a ``PyTree`` and apply all :class:`ParameterWrapper` nodes.
+
+    This leaves all other nodes unchanged. 
+    
+    Note:
+        ``ParameterWrapper`` nodes cannot be nested.
+
+    Example:
+        Enforcing non-negativity.
+
+        >>> import klax
+        >>> import jax.numpy as jnp
+        >>> params = klax.NonNegative(-1 * jnp.ones(3))
+        >>> klax.apply(("abc", 1, params))
+        ('abc', 1, Array([0., 0., 0.], dtype=float32))
+    """
+
+    def _unwrap(tree, *, include_self: bool):
+        def _map_fn(leaf):
+            if isinstance(leaf, ParameterWrapper):
+                # Unwrap subnodes, then itself
+                return _unwrap(leaf, include_self=False).apply()
+            return leaf
+
+        def is_leaf(x):
+            is_unwrappable = isinstance(x, ParameterWrapper)
+            included = include_self or x is not tree
+            return is_unwrappable and included
+
+        return jax.tree.map(f=_map_fn, tree=tree, is_leaf=is_leaf)
+
+    return _unwrap(tree, include_self=True)

--- a/scripts/non_neg_wrapper_test.py
+++ b/scripts/non_neg_wrapper_test.py
@@ -8,9 +8,10 @@ import equinox as eqx
 import jax
 import jax.numpy as jnp
 import jax.random as jr
+from paramax import unwrap
 
-from klax import fit
-from klax.wrappers import NonNegative, unwrap
+from klax import fit, NonNegative, apply
+
 
 
 # %% Define a simple model
@@ -39,6 +40,11 @@ model = SimpleModel()
 # )
 
 print("Initial weight:", unwrap(model).weight)
+print("Initial parameter:", model.weight.parameter)
+
+model = apply(model)
+
+print("Parameter after applying wrapper:", model.weight.parameter)
 
 model, hist = fit(
     model,
@@ -48,5 +54,6 @@ model, hist = fit(
 )
 
 print("Final weight:", unwrap(model).weight)
+print("Final parameter:", model.weight.parameter)
 
 


### PR DESCRIPTION
ParameterWrappers are now a specified version of AbstractUnwrappables that must directly wrap around a jax. Array. They implement the `apply` method, which returns an updated instance of themselves. This can help prevent zero gradients 

TODO:
- [ ] Create tests
- [ ] Update documentation