### PR TITLE
Included license comments in _matrices.py and _icnn.py

### DIFF
--- a/klax/nn/_icnn.py
+++ b/klax/nn/_icnn.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The Klax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """
 Implementation of convex neural networks.
 """

--- a/klax/nn/_matrices.py
+++ b/klax/nn/_matrices.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The Klax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """
 Implementation on (constrained) matrix-valued functions:
 A: R^n |-> R^(..., N, M)


### PR DESCRIPTION
Added license comments to files that were still missing it.