### PR TITLE
Text serialization filter specification

### DIFF
--- a/docs/api/serialization.md
+++ b/docs/api/serialization.md
@@ -1,0 +1,6 @@
+---
+title: Serialization
+---
+
+::: klax.text_serialize_filter_spec
+::: klax.text_deserialize_filter_spec

--- a/docs/examples/isotropic_hyperelasticity.ipynb
+++ b/docs/examples/isotropic_hyperelasticity.ipynb
@@ -426,7 +426,7 @@
       "Step: 18000, Loss: 5.910e-03\n",
       "Step: 19000, Loss: 6.117e-03\n",
       "Step: 20000, Loss: 5.688e-03\n",
-      "Training took: 0:00:04.477259\n"
+      "Training took: 0:00:17.094651\n"
      ]
     },
     {
@@ -517,7 +517,7 @@
     }
    },
    "source": [
-    "Finally, we evaluate the model on the two training cases (*uniaxial*, *biaxial*) and on the *pure shear* test case. Note, that the model needs to be made callable using `klax.finalize`, since the `FICNN` module contains parameters of type `Unwrappable`, which need to be unwrapped be for evaluation."
+    "We evaluate the model on the two training cases (*uniaxial*, *biaxial*) and on the *pure shear* test case. Note, that the model needs to be made callable using `klax.finalize`, since the `FICNN` module contains parameters of type `Unwrappable`, which need to be unwrapped before evaluation."
    ]
   },
   {
@@ -549,8 +549,7 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 0,
+   "cell_type": "markdown",
    "id": "08400fc7",
    "metadata": {
     "collapsed": false,
@@ -559,13 +558,75 @@
      "source_hidden": false
     }
    },
-   "outputs": [],
-   "source": []
+   "source": [
+    "Finally, the model parameters can be saved using Equinox`s [`equinox.tree_serialize_leaves`](https://docs.kidger.site/equinox/api/serialisation/#equinox.tree_serialise_leaves) function. By default it exports to JAX's or Numpy's binary file format. However, to apply the trained model in a finite element simulation (FEM), we usually need to export the parameters in a more universal format.\n",
+    "\n",
+    "For this, the `klax.text_serialize_filter_spec` and `klax.text_deserialize_filter_spec` filter specifications are used, which enable exporting and reading parameters from text files."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "d0060ecf",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "PANN(\n",
+      "  icnn=FICNN(\n",
+      "    layers=(\n",
+      "      Linear(\n",
+      "        weight=NonNegative(parameter=f32[2,8]),\n",
+      "        bias=f32[8],\n",
+      "        in_features=2,\n",
+      "        out_features=8,\n",
+      "        use_bias=True\n",
+      "      ),\n",
+      "      InputSplitLinear(\n",
+      "        weights=(\n",
+      "          NonNegative(parameter=f32[8,1]), NonNegative(parameter=f32[2,1])\n",
+      "        ),\n",
+      "        bias=f32[1],\n",
+      "        in_features=(8, 2),\n",
+      "        out_features='scalar',\n",
+      "        use_bias=True,\n",
+      "        _num_inputs=2\n",
+      "      )\n",
+      "    ),\n",
+      "    activations=(<PjitFunction of <function softplus at 0x000001D34E9CB1A0>>,),\n",
+      "    final_activation=<function FICNN.<lambda>>,\n",
+      "    use_bias=True,\n",
+      "    use_final_bias=True,\n",
+      "    use_passthrough=True,\n",
+      "    non_decreasing=True,\n",
+      "    in_size=2,\n",
+      "    out_size='scalar',\n",
+      "    width_sizes=(8,)\n",
+      "  )\n",
+      ")\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Save the model parameters to a text file\n",
+    "eqx.tree_serialise_leaves(\n",
+    "    \"model.txt\", model, filter_spec=klax.text_serialize_filter_spec\n",
+    ")\n",
+    "\n",
+    "# Load the model parameters from a text file\n",
+    "loaded_model = eqx.tree_deserialise_leaves(\n",
+    "    \"model.txt\", model, filter_spec=klax.text_deserialize_filter_spec\n",
+    ")\n",
+    "\n",
+    "eqx.tree_pprint(loaded_model)"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "klax",
+   "display_name": ".venv",
    "language": "python",
    "name": "python3"
   },

--- a/docs/examples/isotropic_hyperelasticity.ipynb
+++ b/docs/examples/isotropic_hyperelasticity.ipynb
@@ -559,7 +559,7 @@
     }
    },
    "source": [
-    "Finally, the model parameters can be saved using Equinox`s [`equinox.tree_serialize_leaves`](https://docs.kidger.site/equinox/api/serialisation/#equinox.tree_serialise_leaves) function. By default it exports to JAX's or Numpy's binary file format. However, to apply the trained model in a finite element simulation (FEM), we usually need to export the parameters in a more universal format.\n",
+    "Finally, the model parameters can be saved using Equinox's [`equinox.tree_serialize_leaves`](https://docs.kidger.site/equinox/api/serialisation/#equinox.tree_serialise_leaves) function. By default it exports to JAX's or Numpy's binary file format. However, to apply the trained model in a finite element simulation (FEM), we usually need to export the parameters in a more universal format.\n",
     "\n",
     "For this, the `klax.text_serialize_filter_spec` and `klax.text_deserialize_filter_spec` filter specifications are used, which enable exporting and reading parameters from text files."
    ]

--- a/klax/__init__.py
+++ b/klax/__init__.py
@@ -46,6 +46,12 @@ from ._losses import (
 from ._losses import (
     mse as mse,
 )
+from ._serialization import (
+    text_deserialize_filter_spec as text_deserialize_filter_spec,
+)
+from ._serialization import (
+    text_serialize_filter_spec as text_serialize_filter_spec,
+)
 from ._training import fit as fit
 from ._wrappers import (
     Constraint as Constraint,

--- a/klax/_serialization.py
+++ b/klax/_serialization.py
@@ -16,7 +16,6 @@
 
 from typing import Any, BinaryIO
 
-import equinox as eqx
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -50,7 +49,7 @@ def text_serialize_filter_spec(f: BinaryIO, x: Any) -> None:
         f.write(f"{str(x)}\n".encode())
     elif isinstance(x, jax.Array | np.ndarray):
         arr = x.flatten()
-        f.write(f"{' '.join(str(float(v)) for v in arr)}\n".encode())
+        np.savetxt(f, arr[None])
     else:
         pass
 
@@ -85,16 +84,16 @@ def text_deserialize_filter_spec(f: BinaryIO, x: Any) -> Any:
         ```
 
     """
-    line = f.readline().decode().strip()
+    line = f.readline().decode()
     if isinstance(x, (bool, complex, float, int, np.generic)):
         return type(x)(line)
     elif isinstance(x, (jax.Array, jax.ShapeDtypeStruct)):
-        return jnp.array(
-            [float(v) for v in line.split()], dtype=x.dtype
+        return jnp.fromstring(
+            line, dtype=x.dtype, sep=" ", count=x.size
         ).reshape(x.shape)
     elif isinstance(x, np.ndarray):
-        return np.array(
-            [float(v) for v in line.split()], dtype=x.dtype
+        return np.fromstring(
+            line, dtype=x.dtype, sep=" ", count=x.size
         ).reshape(x.shape)
     else:
         return x

--- a/klax/_serialization.py
+++ b/klax/_serialization.py
@@ -23,11 +23,27 @@ import numpy as np
 
 
 def text_serialize_filter_spec(f: BinaryIO, x: Any) -> None:
-    """Filter speficivation for serializing a leaf to text.
+    """Filter specification for serializing a leaf to text.
 
     Args:
         f: File-like object to write to.
         x: The leaf to save in the file.
+
+    Example:
+        Serializing a model to a text file.
+
+        ```python
+        >>> import equinox as eqx
+        >>> import jax.numpy as jnp
+        >>> import klax
+        >>>
+        >>> tree = (jnp.array([1, 2, 3]), [3, 4, 5])
+        >>> eqx.tree_serialize_leaves(
+        ...     "some_txt_file.txt",
+        ...     tree,
+        ...     filter_spec=klax.text_serialize_filter_spec
+        ... )
+        ```
 
     """
     if isinstance(x, (bool, complex, float, int, np.generic)):
@@ -40,11 +56,33 @@ def text_serialize_filter_spec(f: BinaryIO, x: Any) -> None:
 
 
 def text_deserialize_filter_spec(f: BinaryIO, x: Any) -> Any:
-    """Filter speficication for deserializing a leaf from text.
+    """Filter specification for deserializing a leaf from text.
+
+    This function can be used to deserialized leafs that have been serialized
+    using [`klax.text_serialize_filter_spec`][].
 
     Args:
         f: File-like object to read from.
         x: The leaf for which to load data from the file.
+
+    Example:
+        ```python
+        >>> import equinox as eqx
+        >>> import jax.numpy as jnp
+        >>> import klax
+        >>>
+        >>> tree = (jnp.array([1, 2, 3]), [3, 4, 5])
+        >>> eqx.tree_serialize_leaves(
+        ...     "some_txt_file.txt",
+        ...     tree,
+        ...     filter_spec=klax.text_serialize_filter_spec
+        ... )
+        >>> loaded_tree = eqx.tree_deserialize_leaves(
+        ...     "some_txt_file.txt",
+        ...     tree,
+        ...     filter_spec=klax.text_deserialize_filter_spec
+        ... )
+        ```
 
     """
     line = f.readline().decode().strip()

--- a/klax/_serialization.py
+++ b/klax/_serialization.py
@@ -1,0 +1,62 @@
+# Copyright 2025 The Klax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Serialization deseriablizastion specs for `equinox.Module`."""
+
+from typing import Any, BinaryIO
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+
+def text_serialize_filter_spec(f: BinaryIO, x: Any) -> None:
+    """Filter speficivation for serializing a leaf to text.
+
+    Args:
+        f: File-like object to write to.
+        x: The leaf to save in the file.
+
+    """
+    if isinstance(x, (bool, complex, float, int, np.generic)):
+        f.write(f"{str(x)}\n".encode())
+    elif isinstance(x, jax.Array | np.ndarray):
+        arr = x.flatten()
+        f.write(f"{' '.join(str(float(v)) for v in arr)}\n".encode())
+    else:
+        pass
+
+
+def text_deserialize_filter_spec(f: BinaryIO, x: Any) -> Any:
+    """Filter speficication for deserializing a leaf from text.
+
+    Args:
+        f: File-like object to read from.
+        x: The leaf for which to load data from the file.
+
+    """
+    line = f.readline().decode().strip()
+    if isinstance(x, (bool, complex, float, int, np.generic)):
+        return type(x)(line)
+    elif isinstance(x, (jax.Array, jax.ShapeDtypeStruct)):
+        return jnp.array(
+            [float(v) for v in line.split()], dtype=x.dtype
+        ).reshape(x.shape)
+    elif isinstance(x, np.ndarray):
+        return np.array(
+            [float(v) for v in line.split()], dtype=x.dtype
+        ).reshape(x.shape)
+    else:
+        return x

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -103,6 +103,7 @@ nav:
       - api/wrappers.md
       - api/losses.md
       - api/callbacks.md
+      - api/serialization.md
       - Neural Networks:
           - api/nn/linear.md
           - api/nn/mlp.md

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,0 +1,61 @@
+# Copyright 2025 The Klax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from typing import Any, BinaryIO
+
+import equinox as eqx
+import jax.numpy as jnp
+import numpy as np
+
+import klax
+
+
+def _get_pytress():
+    tree = (
+        jnp.array(1),
+        jnp.array([1.0, 2.0]),
+        np.array(1),
+        np.array([1.0, 2.0]),
+        (True, 1, 1.0, 1 + 1j),
+        lambda x: x,
+        object(),
+    )
+    like = (
+        jnp.array(5),
+        jnp.array([6.0, 7.0]),
+        np.array(5),
+        np.array([6.0, 7.0]),
+        (False, 6, 6.0, 6 + 6j),
+        lambda x: x,
+        object(),
+    )
+    return tree, like
+
+
+def test_text_serialize_filter_spec(tmp_path):
+    tree, like = _get_pytress()
+    file_path = tmp_path / "model.eqx"
+
+    eqx.tree_serialise_leaves(
+        file_path, tree, filter_spec=klax.text_serialize_filter_spec
+    )
+
+    tree_loaded = eqx.tree_deserialise_leaves(
+        file_path, like, filter_spec=klax.text_deserialize_filter_spec
+    )
+
+    assert eqx.tree_equal(tree_loaded[:-2], tree[:-2])
+    assert tree_loaded[-2] is like[-2]  # Compare function
+    assert tree_loaded[-1] is like[-1]  # Compare object


### PR DESCRIPTION
A filter specification is proposed that enables serializing model parameters to human-readable text files. 

Test have been added and passed.

The example on isotropic hyperelasticity is extended to showcase the use of the new filter specifications.