### PR TITLE
Added a light wrapper around batch_data that also provides a PRNGKey for model randomness.

### DIFF
--- a/docs/api/training.md
+++ b/docs/api/training.md
@@ -3,6 +3,7 @@ title: Calibration and Data Handling
 ---
 
 ::: klax.batch_data
+::: klax.batch_data_with_key
 ---
 ::: klax.split_data
 ::: klax.fit

--- a/klax/__init__.py
+++ b/klax/__init__.py
@@ -16,6 +16,7 @@ from . import nn as nn
 from ._callbacks import Callback as Callback
 from ._datahandler import BatchGenerator as BatchGenerator
 from ._datahandler import batch_data as batch_data
+from ._datahandler import batch_data_with_key as batch_data_with_key
 from ._datahandler import split_data as split_data
 from ._initializers import Initializer as Initializer
 from ._initializers import SupportedInitializer as SupportedInitializer

--- a/klax/_datahandler.py
+++ b/klax/_datahandler.py
@@ -92,23 +92,23 @@ class BatchGenerator(Protocol):
         raise NotImplementedError
 
 
-def batch_data(
-    data: PyTree[Any],
-    batch_size: int = 32,
+def batch_data[T](
+    data: PyTree[Any, "T"],
+    batch_size: int,
     batch_axes: PyTree[int | None] = 0,
     convert_to_numpy: bool = True,
     *,
     key: PRNGKeyArray,
-) -> Generator[PyTree[Any], None, None]:
+) -> Generator[PyTree[Any, "T"], None, None]:
     """Create a `Generator` that draws subsets of data without replacement.
 
     The data can be any `PyTree` with `ArrayLike` leaves. If `batch_axes` is
     passed, batch axes (including `None` for no batching) can be specified for
-    every leaf individualy.
-    A generator is returned that indefinetly yields batches of data with size
+    every leaf individually.
+    A generator is returned that indefinitely yields batches of data with size
     `batch_size`. Examples are drawn without replacement until the remaining
     dataset is smaller than `batch_size`, at which point the dataset will be
-    reshuffeld and the process starts over.
+    reshuffled and the process starts over.
 
     Example:
         This is an example for a nested `PyTree`, where the elements x and y
@@ -123,7 +123,7 @@ def batch_data(
         >>> y = jnp.array([[1.], [2.]])
         >>> data = (x, {"a": 1.0, "b": y})
         >>> batch_axes = (0, {"a": None, "b": 0})
-        >>> iter_data = klax.batch_data(
+        >>> batch = klax.batch_data(
         ...     data,
         ...     32,
         ...     batch_axes,
@@ -149,16 +149,15 @@ def batch_data(
             generation. (Keyword only argument.)
 
     Returns:
-        A `Generator` that yields a random batch of data every time is is
-        called.
+        A `Generator` that yields a random batch of data.
 
     Yields:
         A `PyTree[ArrayLike]` with the same structure as `data`. Where all
-        batched leaves have `batch_size`.
+            batched leaves have `batch_size`.
 
     Note:
         Note that if the size of the dataset is smaller than `batch_size`, the
-        obtained batches will have dataset size.
+        used `batch_size` will be reduced.
 
     """
     batch_axes, dataset_size = broadcast_and_get_size(data, batch_axes)
@@ -192,6 +191,81 @@ def batch_data(
             )
             start = end
             end = start + batch_size
+
+
+def batch_data_with_key[T](
+    data: PyTree[Any, "T"],
+    batch_size: int,
+    batch_axes: PyTree[int | None] = 0,
+    convert_to_numpy: bool = True,
+    key_per_sample: bool = False,
+    *,
+    key: PRNGKeyArray,
+) -> Generator[tuple[PyTree[Any, "T"], PRNGKeyArray], None, None]:
+    """Create a `Generator` of `batch, key` tuples.
+
+    This is a wrapper around [`batch_data`][klax.batch_data] that also yields
+    a PRNG key together with the batch from [`batch_data`][klax.batch_data].
+    The key is updated every time a new
+    batch is drawn, so it can be used to provide randomness for the training
+    step that uses the batch. There are options to provide a key per batch
+    or per sample.
+
+
+    The data can be any `PyTree` with `ArrayLike` leaves. If `batch_axes` is
+    passed, batch axes (including `None` for no batching) can be specified for
+    every leaf individually.
+    A generator is returned that indefinitely yields batches of data with size
+    `batch_size`. Examples are drawn without replacement until the remaining
+    dataset is smaller than `batch_size`, at which point the dataset will be
+    reshuffled and the process starts over.
+
+    Args:
+        data: The data that shall be batched. It can be any `PyTree` with
+            `ArrayLike` leaves.
+        batch_size: The number of examples in a batch.
+        batch_axes: PyTree of the batch axis indices. `None` is used to
+            indicate that the corresponding leaf or subtree in data does not
+            have a batch axis. `batch_axes` must have the same structure as
+            `data` or have `data` as a prefix.
+            (Defaults to 0, meaning all leaves in `data` are
+            batched along their first dimension.)
+        convert_to_numpy: If `True`, batched data leafs will be converted to
+            Numpy arrays before batching. This is useful for performance
+            reasons, as Numpy's slicing is much faster than JAX's.
+        key_per_sample: If `True`, a separate key will be provided for each
+            sample in the batch. If `False`, a single key will be provided
+            for the whole batch.
+        key: A `jax.random.PRNGKey` used to provide randomness for batch
+            generation. (Keyword only argument.)
+
+    Returns:
+        A `Generator` that yields a random (batch, key) tuple.
+
+    Yields:
+        A tuple `(PyTree[ArrayLike], PRNGKeyArray)`. The pytree has the
+            same structure as `data` and all batched leaves have `batch_size`.
+            PRNGKeyArray is either a single key for the whole batch or an array
+            of keys for each sample in the batch.
+
+    Note:
+        Note that if the size of the dataset is smaller than `batch_size`, the
+        used `batch_size` will be reduced.
+
+    """
+    batcher_key, key = jax.random.split(key)
+    batch = batch_data(
+        data,
+        batch_size,
+        batch_axes,
+        convert_to_numpy=convert_to_numpy,
+        key=batcher_key,
+    )
+    while True:
+        key, batch_key = jax.random.split(key)
+        if key_per_sample:
+            batch_key = jax.random.split(batch_key, batch_size)
+        yield next(batch), batch_key
 
 
 def split_data(

--- a/scripts/simple_training.py
+++ b/scripts/simple_training.py
@@ -28,6 +28,13 @@ class MyCallback(klax.Callback):
             )
 
 
+@klax.loss
+def my_loss(model, batch, batch_axes):
+    (x, y), key = batch
+    y_pred = jax.vmap(model, in_axes=batch_axes)(x)
+    return jnp.mean((y - y_pred) ** 2)
+
+
 model, history = klax.fit(
     model,
     (x, y),
@@ -35,6 +42,8 @@ model, history = klax.fit(
     steps=30_000,
     logger=logger,
     # callbacks=[MyCallback()],
+    batcher=klax.batch_data_with_key,
+    loss=my_loss,
     key=train_key,
 )
 

--- a/tests/test_datahandler.py
+++ b/tests/test_datahandler.py
@@ -25,19 +25,19 @@ class TestBatchData:
     def test_with_single_array(self, getkey):
         x = jrandom.uniform(getkey(), (64,))
         data = x
-        generator = batch_data(data, key=getkey())
+        generator = batch_data(data, batch_size=32, key=getkey())
         assert jax.tree.structure(next(generator)) == jax.tree.structure(data)
 
     def test_with_nested_pytree(self, getkey):
         x = jrandom.uniform(getkey(), (10,))
         data = [x, (x, {"a": x, "b": x})]
-        generator = batch_data(data, key=getkey())
+        generator = batch_data(data, batch_size=32, key=getkey())
         assert jax.tree.structure(next(generator)) == jax.tree.structure(data)
 
     def test_batch_size(self, getkey):
         x = jrandom.uniform(getkey(), (33,))
         data = x
-        generator = batch_data(data, key=getkey())
+        generator = batch_data(data, batch_size=32, key=getkey())
         assert next(generator).shape[0] == 32
 
     def test_batch_size_larger_than_data(self, getkey):
@@ -70,7 +70,7 @@ class TestBatchData:
         x = jrandom.uniform(getkey(), (10,))
         y = jrandom.uniform(getkey(), (5,))
         data = (x, y)
-        generator = batch_data(data, key=getkey())
+        generator = batch_data(data, batch_size=32, key=getkey())
         with pytest.raises(
             ValueError, match="All batched arrays must have equal batch sizes."
         ):

--- a/tests/test_datahandler.py
+++ b/tests/test_datahandler.py
@@ -13,97 +13,119 @@
 # limitations under the License.
 
 import equinox as eqx
+import jax
 import jax.random as jrandom
 import numpy as np
 import pytest
 
-from klax import batch_data, split_data
+from klax import batch_data, batch_data_with_key, split_data
 
 
-def test_batch_data(getkey):
-    # Sequence with one element
-    x = jrandom.uniform(getkey(), (10,))
-    data = (x,)
-    generator = batch_data(data, key=getkey())
-    assert isinstance(next(generator), tuple)
-    assert len(next(generator)) == 1
-
-    # Nested PyTree
-    x = jrandom.uniform(getkey(), (10,))
-    data = [x, (x, {"a": x, "b": x})]
-    generator = batch_data(data, key=getkey())
-    assert isinstance(next(generator), list)
-    assert len(next(generator)) == 2
-    assert isinstance(next(generator)[1], tuple)
-    assert len(next(generator)[1]) == 2
-    assert isinstance(next(generator)[1][1], dict)
-    assert len(next(generator)[1][1]) == 2
-
-    # Default batch size
-    x = jrandom.uniform(getkey(), (33,))
-    data = (x,)
-    generator = batch_data(data, key=getkey())
-    assert next(generator)[0].shape[0] == 32
-
-    # Batch mask
-    x = jrandom.uniform(getkey(), (10,))
-    data = (x, (x, x))
-    batch_axes = (0, (None, 0))
-    generator = batch_data(data, 2, batch_axes, key=getkey())
-    assert next(generator)[0].shape[0] == 2
-    assert next(generator)[1][0].shape[0] == 10
-    assert next(generator)[1][1].shape[0] == 2
-
-    # No batch dimensions
-    x = jrandom.uniform(getkey(), (10,))
-    data = (x,)
-    batch_axes = None
-    generator = batch_data(data, batch_axes=batch_axes, key=getkey())
-    assert next(generator) == data
-
-    # Different batch sizes
-    x = jrandom.uniform(getkey(), (10,))
-    y = jrandom.uniform(getkey(), (5,))
-    data = (x, y)
-    with pytest.raises(
-        ValueError, match="All batched arrays must have equal batch sizes."
-    ):
+class TestBatchData:
+    def test_with_single_array(self, getkey):
+        x = jrandom.uniform(getkey(), (64,))
+        data = x
         generator = batch_data(data, key=getkey())
-        next(generator)
+        assert jax.tree.structure(next(generator)) == jax.tree.structure(data)
 
-    # Smaller data than batch dimension
-    x = jrandom.uniform(getkey(), (10,))
-    generator = batch_data(x, batch_size=128, key=getkey())
-    assert next(generator).shape == (10,)
+    def test_with_nested_pytree(self, getkey):
+        x = jrandom.uniform(getkey(), (10,))
+        data = [x, (x, {"a": x, "b": x})]
+        generator = batch_data(data, key=getkey())
+        assert jax.tree.structure(next(generator)) == jax.tree.structure(data)
+
+    def test_batch_size(self, getkey):
+        x = jrandom.uniform(getkey(), (33,))
+        data = x
+        generator = batch_data(data, key=getkey())
+        assert next(generator).shape[0] == 32
+
+    def test_batch_size_larger_than_data(self, getkey):
+        x = jrandom.uniform(getkey(), (10,))
+        data = x
+        generator = batch_data(data, batch_size=128, key=getkey())
+        assert next(generator).shape == (10,)
+
+    def test_different_batch_axes(self, getkey):
+        x = jrandom.uniform(getkey(), (10,))
+        data = (x, (x, x))
+        batch_axes = (0, (None, 0))
+        generator = batch_data(
+            data, batch_size=2, batch_axes=batch_axes, key=getkey()
+        )
+        assert next(generator)[0].shape[0] == 2
+        assert next(generator)[1][0].shape[0] == 10
+        assert next(generator)[1][1].shape[0] == 2
+
+    def test_no_batch_axes(self, getkey):
+        x = jrandom.uniform(getkey(), (10,))
+        data = (x,)
+        batch_axes = None
+        generator = batch_data(
+            data, batch_size=2, batch_axes=batch_axes, key=getkey()
+        )
+        assert next(generator) == data
+
+    def test_different_batch_sizes(self, getkey):
+        x = jrandom.uniform(getkey(), (10,))
+        y = jrandom.uniform(getkey(), (5,))
+        data = (x, y)
+        generator = batch_data(data, key=getkey())
+        with pytest.raises(
+            ValueError, match="All batched arrays must have equal batch sizes."
+        ):
+            next(generator)
 
 
-def test_split_data(getkey):
-    # Nestes data structure with different batch axes
-    batch_size = 20
-    data = (
-        jrandom.uniform(getkey(), (batch_size, 2)),
-        [
-            jrandom.uniform(getkey(), (3, batch_size, 2)),
-            100.0,
-            "test",
-            None,
-        ],
-    )
-    proportions = (2, 1, 1)
-    batch_axes = (0, 1)
-    subsets = split_data(data, proportions, batch_axes, key=getkey())
+class TestBatchDataWithKey:
+    def test_with_single_array(self, getkey):
+        x = jrandom.uniform(getkey(), (10,))
+        data = x
+        generator = batch_data_with_key(
+            data, batch_size=2, batch_axis=0, key=getkey()
+        )
+        batch, key = next(generator)
+        assert jax.tree.structure(batch) == jax.tree.structure(data)
+        assert isinstance(key, jax.Array)
 
-    for s, p in zip(subsets, (0.5, 0.25, 0.25)):
-        assert s[0].shape == (round(p * batch_size), 2)
-        assert s[1][0].shape == (3, round(p * batch_size), 2)
-        assert eqx.tree_equal(s[1][1:], data[1][1:])
+    def test_with_nested_pytree(self, getkey):
+        x = jrandom.uniform(getkey(), (10,))
+        data = [x, (x, {"a": x, "b": x})]
+        generator = batch_data_with_key(
+            data, batch_size=2, batch_axis=0, key=getkey()
+        )
+        batch, key = next(generator)
+        assert jax.tree.structure(batch) == jax.tree.structure(data)
+        assert isinstance(key, jax.Array)
 
-    # One-element data structure
-    data = np.arange(10)
-    (s,) = split_data(data, (1.0,), key=getkey())
-    assert np.array_equal(data, np.sort(s))
 
-    # Negative proportion
-    data = np.arange(10)
-    with pytest.raises(ValueError):
-        split_data(data, (-1.0,), key=getkey())
+class TestSplitData:
+    def test_split_data(self, getkey):
+        batch_size = 20
+        data = (
+            jrandom.uniform(getkey(), (batch_size, 2)),
+            [
+                jrandom.uniform(getkey(), (3, batch_size, 2)),
+                100.0,
+                "test",
+                None,
+            ],
+        )
+        proportions = (2, 1, 1)
+        batch_axes = (0, 1)
+        subsets = split_data(data, proportions, batch_axes, key=getkey())
+
+        for s, p in zip(subsets, (0.5, 0.25, 0.25)):
+            assert s[0].shape == (round(p * batch_size), 2)
+            assert s[1][0].shape == (3, round(p * batch_size), 2)
+            assert eqx.tree_equal(s[1][1:], data[1][1:])
+
+    def test_with_singleton_split(self, getkey):
+        data = np.arange(10)
+        (s,) = split_data(data, (1,), key=getkey())
+        assert np.array_equal(data, np.sort(s))
+
+    def test_with_zero_proportion(self, getkey):
+        data = np.arange(10)
+        with pytest.raises(ValueError):
+            split_data(data, (-1.0,), key=getkey())


### PR DESCRIPTION
When training models that depend on randomness (dropout layers, VAEs, ...) the model evaluation requires a PRNGKey. This PR introduces a new `BatchGenerator` that yields tuples of batches and keys. Batches are generated via the default `batch_data`, while the keys are freshly created for each batch.