### PR TITLE
Change I/O of `run_training_loop` to `TrainingView`

### DIFF
--- a/docs/api/callbacks.md
+++ b/docs/api/callbacks.md
@@ -13,9 +13,3 @@ a jax-incompatible way.
             - on_training_start
             - on_training_step
             - on_training_end
-
----
-
-::: klax.TrainingView
-    options:
-        members: false

--- a/docs/api/training.md
+++ b/docs/api/training.md
@@ -10,6 +10,14 @@ title: Calibration and Data Handling
 
 ---
 
+::: klax.run_training_loop
+::: klax.make_step
+
+---
+
+::: klax.TrainingView
+    options:
+        members: false
 ::: klax.TrainingState
     options:
         members: false
@@ -20,5 +28,3 @@ title: Calibration and Data Handling
             - disassemble_model
             - assemble_opt_state
             - disassemble_opt_state
-::: klax.make_step
-::: klax.run_training_loop

--- a/klax/__init__.py
+++ b/klax/__init__.py
@@ -44,7 +44,7 @@ from ._training import run_training_loop as run_training_loop
 from ._trainstate import TrainingState as TrainingState
 from ._trainstate import TrainingStatic as TrainingStatic
 from ._trainstate import TrainingView as TrainingView
-from ._trainstate import make_state_and_static as make_state_and_static
+from ._trainstate import make_view as make_view
 from ._wrappers import Constraint as Constraint
 from ._wrappers import NonNegative as NonNegative
 from ._wrappers import NonTrainable as NonTrainable

--- a/klax/_training.py
+++ b/klax/_training.py
@@ -35,7 +35,7 @@ from ._trainstate import (
     TrainingState,
     TrainingStatic,
     TrainingView,
-    make_state_and_static,
+    make_view,
 )
 from ._wrappers import apply
 
@@ -95,26 +95,25 @@ def make_step(
 
 
 def run_training_loop(
-    state: TrainingState,
-    static: TrainingStatic,
+    view: TrainingView,
     callbacks: Iterable[Callback],
-) -> TrainingState:
+) -> TrainingView:
     """Iterate [`make_step`][klax.make_step] in pure python with callback integration.
 
     Args:
-        state: Initial [TrainingState][klax.TrainingState]
-        static: [TrainingStatic][klax.TrainingStatic]
+        view: [TrainingView][klax.TrainingView]
         callbacks: Iterable of [Callback][klax.Callback] instances.
 
     Returns:
-        Final [TrainingState][klax.TrainingState].
+        Final [TrainingView][klax.TrainingView].
 
     """
     step = 0
-    view = TrainingView(state, static)
     for callback in callbacks:
         callback.on_training_start(view, step)
 
+    state = view.state
+    static = view.static
     for step in range(1, static.steps + 1):
         state = make_step(state, next(static.batch), static)
 
@@ -128,7 +127,8 @@ def run_training_loop(
     for callback in callbacks:
         callback.on_training_end(view, step)
 
-    return state
+    view = TrainingView(state, static)
+    return view
 
 
 def fit[T: eqx.Module, H: Callback](
@@ -249,7 +249,7 @@ def fit[T: eqx.Module, H: Callback](
 
     bkey, key = jax.random.split(key)
     batch = batcher(data, batch_size, batch_axes, key=bkey)
-    state, static = make_state_and_static(
+    view = make_view(
         model,
         optimizer,
         opt_state,
@@ -289,9 +289,9 @@ def fit[T: eqx.Module, H: Callback](
             )
         callbacks.append(logger)
 
-    state = run_training_loop(state, static, callbacks)
+    view = run_training_loop(view, callbacks)
 
-    model = static.assemble_model(state.model_leaves)
+    model = view.static.assemble_model(view.state.model_leaves)
 
     history = logger.history if logger is not None else History()
 

--- a/klax/_trainstate.py
+++ b/klax/_trainstate.py
@@ -14,13 +14,17 @@
 
 from collections.abc import Generator
 from dataclasses import dataclass
-from typing import Any, Self
+from typing import Any
 
 import jax
 import optax
 from jaxtyping import PyTree, PyTreeDef
 
 from klax._losses import Loss
+
+# ====--------------------------------------------------------------------=== #
+# TrainingView classes
+# ====--------------------------------------------------------------------=== #
 
 
 @jax.tree_util.register_dataclass
@@ -75,58 +79,6 @@ class TrainingStatic:
         return leaves
 
 
-def make_state_and_static(
-    model: PyTree[Any],
-    optimizer: optax.GradientTransformation
-    | optax.GradientTransformationExtraArgs,
-    opt_state: PyTree[Any],
-    batch: Generator[PyTree[Any], None, None],
-    batch_axes: PyTree[int | None],
-    loss: Loss,
-    steps: int,
-) -> tuple[TrainingState, TrainingStatic]:
-    """Create the initial TrainingState and TrainingStatic from the model and optimizer.
-
-    Args:
-        model: The initial model parameters.
-        optimizer: The optimizer to use for training.
-        opt_state: The initial optimizer state.
-        batch: A generator that yields batches of data.
-        batch_axes: A PyTree indicating the batch axes for each component of the data.
-        loss: The loss function to use for training.
-        steps: The total number of training steps.
-
-    Returns:
-        A tuple of (TrainingState, TrainingStatic).
-
-    """
-    model_leaves, model_treedef = jax.tree.flatten(model)
-    opt_state_leaves, opt_state_treedef = jax.tree.flatten(opt_state)
-
-    optimizer = (
-        optax.with_extra_args_support(optimizer)
-        if not isinstance(optimizer, optax.GradientTransformationExtraArgs)
-        else optimizer
-    )
-
-    state = TrainingState(
-        model_leaves=model_leaves,
-        opt_state_leaves=opt_state_leaves,
-    )
-
-    static = TrainingStatic(
-        model_tree_def=model_treedef,
-        optimizer=optimizer,
-        opt_state_tree_def=opt_state_treedef,
-        batch=batch,
-        batch_axes=batch_axes,
-        loss=loss,
-        steps=steps,
-    )
-
-    return state, static
-
-
 # This is similar to the old CallbackArgs, but ensures a clean separation
 # between mutable state (TrainingState) and static components (TrainingStatic),
 # while providing a nice public-facing interface to access and modify the model
@@ -179,3 +131,60 @@ class TrainingView:
     def opt_state(self, value):
         self.state.opt_state_leaves = self.static.disassemble_opt_state(value)
         self._opt_state = value
+
+
+# ====--------------------------------------------------------------------=== #
+# Factory methods
+# ====--------------------------------------------------------------------=== #
+
+
+def make_view(
+    model: PyTree[Any],
+    optimizer: optax.GradientTransformation
+    | optax.GradientTransformationExtraArgs,
+    opt_state: PyTree[Any],
+    batch: Generator[PyTree[Any], None, None],
+    batch_axes: PyTree[int | None],
+    loss: Loss,
+    steps: int,
+) -> TrainingView:
+    """Create the TrainingView from the model and optimizer.
+
+    Args:
+        model: The initial model parameters.
+        optimizer: The optimizer to use for training.
+        opt_state: The initial optimizer state.
+        batch: A generator that yields batches of data.
+        batch_axes: A PyTree indicating the batch axes for each component of the data.
+        loss: The loss function to use for training.
+        steps: The total number of training steps.
+
+    Returns:
+        A TrainingView.
+
+    """
+    model_leaves, model_treedef = jax.tree.flatten(model)
+    opt_state_leaves, opt_state_treedef = jax.tree.flatten(opt_state)
+
+    optimizer = (
+        optax.with_extra_args_support(optimizer)
+        if not isinstance(optimizer, optax.GradientTransformationExtraArgs)
+        else optimizer
+    )
+
+    state = TrainingState(
+        model_leaves=model_leaves,
+        opt_state_leaves=opt_state_leaves,
+    )
+
+    static = TrainingStatic(
+        model_tree_def=model_treedef,
+        optimizer=optimizer,
+        opt_state_tree_def=opt_state_treedef,
+        batch=batch,
+        batch_axes=batch_axes,
+        loss=loss,
+        steps=steps,
+    )
+
+    return TrainingView(state, static)

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -50,7 +50,7 @@ class TestMakeStep:
         y = jnp.array([3.0, 7.0])
         batch = klax.batch_data((x, y), batch_size=32, key=getkey())
 
-        state, static = klax.make_state_and_static(
+        view = klax.make_view(
             model=model,
             optimizer=optimizer,
             opt_state=opt_state,
@@ -60,7 +60,9 @@ class TestMakeStep:
             steps=5,
         )
 
-        new_state = klax.make_step(state, next(static.batch), static)
+        new_state = klax.make_step(
+            view.state, next(view.static.batch), view.static
+        )
 
         # State has changed
         assert not jax.tree.all(
@@ -68,7 +70,7 @@ class TestMakeStep:
                 lambda a, b: jnp.array_equal(a, b)
                 if isinstance(a, jnp.ndarray)
                 else a == b,
-                state.model_leaves,
+                view.state.model_leaves,
                 new_state.model_leaves,
             )
         )
@@ -99,7 +101,7 @@ class TestRunTrainingLoop:
         y = jnp.array([3.0, 7.0])
         batch = klax.batch_data((x, y), batch_size=32, key=getkey())
 
-        state, static = klax.make_state_and_static(
+        view = klax.make_view(
             model=model,
             optimizer=optimizer,
             opt_state=opt_state,
@@ -111,7 +113,7 @@ class TestRunTrainingLoop:
 
         callback = RecordingCallback()
 
-        new_state = klax.run_training_loop(state, static, [callback])
+        updated_view = klax.run_training_loop(view, [callback])
 
         assert callback.start_steps == [0]
         assert callback.steps == [1, 2, 3]
@@ -121,8 +123,8 @@ class TestRunTrainingLoop:
                 lambda a, b: jnp.array_equal(a, b)
                 if isinstance(a, jnp.ndarray)
                 else a == b,
-                state.model_leaves,
-                new_state.model_leaves,
+                view.state.model_leaves,
+                updated_view.state.model_leaves,
             )
         )
 
@@ -150,7 +152,7 @@ class TestRunTrainingLoop:
         y = jnp.array([3.0, 7.0])
         batch = klax.batch_data((x, y), batch_size=32, key=getkey())
 
-        state, static = klax.make_state_and_static(
+        view = klax.make_view(
             model=model,
             optimizer=optimizer,
             opt_state=opt_state,
@@ -162,7 +164,7 @@ class TestRunTrainingLoop:
 
         callback = RecordingCallback()
 
-        new_state = klax.run_training_loop(state, static, [callback])
+        updated_view = klax.run_training_loop(view, [callback])
 
         assert callback.start_steps == [0]
         assert callback.steps == []
@@ -172,8 +174,8 @@ class TestRunTrainingLoop:
                 lambda a, b: jnp.array_equal(a, b)
                 if isinstance(a, jnp.ndarray)
                 else a == b,
-                state.model_leaves,
-                new_state.model_leaves,
+                view.state.model_leaves,
+                updated_view.state.model_leaves,
             )
         )
 
@@ -198,7 +200,7 @@ class TestRunTrainingLoop:
         y = jnp.array([3.0, 7.0])
         batch = klax.batch_data((x, y), batch_size=32, key=getkey())
 
-        state, static = klax.make_state_and_static(
+        view = klax.make_view(
             model=model,
             optimizer=optimizer,
             opt_state=opt_state,
@@ -210,7 +212,7 @@ class TestRunTrainingLoop:
 
         callback = StopAfterOne()
 
-        new_state = klax.run_training_loop(state, static, [callback])
+        updated_view = klax.run_training_loop(view, [callback])
 
         assert callback.steps == [1]
         assert callback.end_steps == [1]
@@ -219,8 +221,8 @@ class TestRunTrainingLoop:
                 lambda a, b: jnp.array_equal(a, b)
                 if isinstance(a, jnp.ndarray)
                 else a == b,
-                state.model_leaves,
-                new_state.model_leaves,
+                view.state.model_leaves,
+                updated_view.state.model_leaves,
             )
         )
 

--- a/tests/test_trainstate.py
+++ b/tests/test_trainstate.py
@@ -3,7 +3,7 @@ import jax.numpy as jnp
 import optax
 import pytest
 
-from klax._trainstate import TrainingView, make_state_and_static
+from klax import make_view
 
 
 def tree_allclose(a, b):
@@ -22,13 +22,13 @@ def dummy_batch():
         yield {"x": jnp.array([0.0])}
 
 
-class TestTrainstate:
-    def test_make_state_and_static_wraps_optimizer_and_sets_defs(self):
+class TestTrainingView:
+    def test_make_view_wraps_optimizer_and_sets_defs(self):
         model = {"w": jnp.array([1.0, 2.0]), "b": jnp.array(0.0)}
         opt_state = {"m": {"w": jnp.zeros(2), "b": jnp.zeros(())}}
         optimizer = optax.adam(1e-3)
 
-        state, static = make_state_and_static(
+        view = make_view(
             model=model,
             optimizer=optimizer,
             opt_state=opt_state,
@@ -41,19 +41,19 @@ class TestTrainstate:
         # Leaves and tree defs are set
         m_leaves, m_treedef = jax.tree.flatten(model)
         o_leaves, o_treedef = jax.tree.flatten(opt_state)
-        assert state.model_leaves == m_leaves
-        assert state.opt_state_leaves == o_leaves
-        assert static.model_tree_def == m_treedef
-        assert static.opt_state_tree_def == o_treedef
+        assert view.state.model_leaves == m_leaves
+        assert view.state.opt_state_leaves == o_leaves
+        assert view.static.model_tree_def == m_treedef
+        assert view.static.opt_state_tree_def == o_treedef
 
         # Optimizer is wrapped with extra args support
         assert isinstance(
-            static.optimizer, optax.GradientTransformationExtraArgs
+            view.static.optimizer, optax.GradientTransformationExtraArgs
         )
 
         # If already wrapped, keep identity
         wrapped = optax.with_extra_args_support(optax.sgd(1.0))
-        _, static2 = make_state_and_static(
+        view2 = make_view(
             model=model,
             optimizer=wrapped,
             opt_state=opt_state,
@@ -62,28 +62,28 @@ class TestTrainstate:
             loss=object(),
             steps=3,
         )
-        assert static2.optimizer is wrapped
+        assert view2.static.optimizer is wrapped
 
     def test_assemble_disassemble_model_and_opt_state(self):
         model = {"w": jnp.array([1.0, 2.0]), "b": jnp.array(0.0)}
         opt_state = {"m": {"w": jnp.zeros(2), "b": jnp.zeros(())}}
         optimizer = optax.adam(1e-3)
 
-        state, static = make_state_and_static(
+        view = make_view(
             model, optimizer, opt_state, dummy_batch(), 0, object(), 2
         )
 
-        model_round = static.assemble_model(state.model_leaves)
+        model_round = view.static.assemble_model(view.state.model_leaves)
         tree_allclose(model_round, model)
 
-        leaves = static.disassemble_model(model_round)
-        assert leaves == state.model_leaves
+        leaves = view.static.disassemble_model(model_round)
+        assert leaves == view.state.model_leaves
 
-        opt_round = static.assemble_opt_state(state.opt_state_leaves)
+        opt_round = view.static.assemble_opt_state(view.state.opt_state_leaves)
         tree_allclose(opt_round, opt_state)
 
-        o_leaves = static.disassemble_opt_state(opt_round)
-        assert o_leaves == state.opt_state_leaves
+        o_leaves = view.static.disassemble_opt_state(opt_round)
+        assert o_leaves == view.state.opt_state_leaves
 
     def test_disassemble_model_mismatch_raises(self):
         model = {"w": jnp.array([1.0, 2.0]), "b": jnp.array(0.0)}
@@ -91,12 +91,12 @@ class TestTrainstate:
         opt_state = {"m": {"w": jnp.zeros(2), "b": jnp.zeros(())}}
         optimizer = optax.adam(1e-3)
 
-        _, static = make_state_and_static(
+        view = make_view(
             model, optimizer, opt_state, dummy_batch(), 0, object(), 2
         )
 
         with pytest.raises(ValueError, match="Model structure changed"):
-            static.disassemble_model(other)
+            view.static.disassemble_model(other)
 
     def test_disassemble_opt_state_mismatch_raises(self):
         model = {"w": jnp.array([1.0, 2.0]), "b": jnp.array(0.0)}
@@ -104,23 +104,22 @@ class TestTrainstate:
         other_opt = {"m": {"w": jnp.zeros(2), "c": jnp.zeros(())}}
         optimizer = optax.adam(1e-3)
 
-        _, static = make_state_and_static(
+        view = make_view(
             model, optimizer, opt_state, dummy_batch(), 0, object(), 2
         )
 
         with pytest.raises(ValueError, match="Opt state structure changed"):
-            static.disassemble_opt_state(other_opt)
+            view.static.disassemble_opt_state(other_opt)
 
     def test_trainingview_model_property_caching_and_setter(self):
         model = {"w": jnp.array([1.0, 2.0]), "b": jnp.array(0.0)}
         opt_state = {"m": {"w": jnp.zeros(2), "b": jnp.zeros(())}}
         optimizer = optax.adam(1e-3)
 
-        state, static = make_state_and_static(
+        view = make_view(
             model, optimizer, opt_state, dummy_batch(), 0, object(), 2
         )
 
-        view = TrainingView(state, static)
         # Getter assembles and caches
         m1 = view.model
         tree_allclose(m1, model)
@@ -129,7 +128,7 @@ class TestTrainstate:
         new_model = {"w": model["w"] + 1, "b": model["b"] + 1}
         view.model = new_model
         tree_allclose(view.model, new_model)
-        roundtrip = static.assemble_model(state.model_leaves)
+        roundtrip = view.static.assemble_model(view.state.model_leaves)
         tree_allclose(roundtrip, new_model)
 
     def test_trainingview_opt_state_getter_setter(self):
@@ -137,11 +136,10 @@ class TestTrainstate:
         opt_state = {"m": {"w": jnp.zeros(2), "b": jnp.zeros(())}}
         optimizer = optax.adam(1e-3)
 
-        state, static = make_state_and_static(
+        view = make_view(
             model, optimizer, opt_state, dummy_batch(), 0, object(), 2
         )
 
-        view = TrainingView(state, static)
         # Getter assembles and returns opt state
         os1 = view.opt_state
         tree_allclose(os1, opt_state)
@@ -150,5 +148,5 @@ class TestTrainstate:
         new_opt = {"m": {"w": jnp.ones(2), "b": jnp.ones(())}}
         view.opt_state = new_opt
         tree_allclose(view.opt_state, new_opt)
-        roundtrip = static.assemble_opt_state(state.opt_state_leaves)
+        roundtrip = view.static.assemble_opt_state(view.state.opt_state_leaves)
         tree_allclose(roundtrip, new_opt)


### PR DESCRIPTION
Changes:
- Instead of passing `state` and `static` separately to `run_training_loop`. We directly pass the `view`. Since, the view is also the input into the Callbacks, this makes the API a bit more consistent. With this change, one could upgrade `run_training_view` to being the main `fit` function. In addition to a `simple_fit` function that sets some defaults for certain callbacks and internally assembles the `view`
- `make_static_and_state` was renamed to `make_view` and now returns a view directly
- `TrainingView` was moved out of the callback and into the training section of the API, since it is now used in `run_training_loop`