### PR TITLE
Feature/simple-api3

### DIFF
--- a/docs/api/callbacks.md
+++ b/docs/api/callbacks.md
@@ -13,9 +13,3 @@ a jax-incompatible way.
             - on_training_start
             - on_training_step
             - on_training_end
-
----
-
-::: klax.TrainingView
-    options:
-        members: false

--- a/docs/api/logging.md
+++ b/docs/api/logging.md
@@ -2,14 +2,16 @@
 title: Logging
 ---
 
-While you can implement arbitrary logging functionality by creating a custom [Callback][klax.Callback], klax provides basic logging functionality with the [MetricLogger][klax.MetricLogger]. At it's core is the concept of a [Metric][klax.Metric]: A simple function, that maps a model to some value (or object). A basic and common metric is the [Evaluator][klax.Evaluator], which samples a batch from a dataset and evaluates the model on a function such as a [loss function][klax.Loss]. 
+While you can implement arbitrary logging functionality by creating a custom [Callback][klax.Callback], klax provides basic logging functionality with the [MetricLogger][klax.MetricLogger]. At it's core is the concept of a [Metric][klax.Metric]: A simple function, that maps a model to some value (or object). A basic and common metric is the [BatchMetric][klax.BatchMetric], which samples a batch from a dataset and evaluates the model on a function such as a [loss function][klax.Loss]. 
 The [MetricLogger][klax.MetricLogger] keeps track of multiple [Metrics][klax.Metric] and evaluates them during training. The resulting metric values are written to a dict-like [history object][klax.History]. Besides storing the metrics, [histories][klax.History] provide basic functionality to save, load, combine and plot metrics.
 
 ::: klax.Metric
     options:
         members: false
 
-::: klax.Evaluator
+::: klax.metric
+
+::: klax.BatchMetric
     options:
         members:
             - __init__

--- a/docs/api/training.md
+++ b/docs/api/training.md
@@ -10,6 +10,14 @@ title: Calibration and Data Handling
 
 ---
 
+::: klax.run_training_loop
+::: klax.make_step
+
+---
+
+::: klax.TrainingView
+    options:
+        members: false
 ::: klax.TrainingState
     options:
         members: false
@@ -20,5 +28,3 @@ title: Calibration and Data Handling
             - disassemble_model
             - assemble_opt_state
             - disassemble_opt_state
-::: klax.make_step
-::: klax.run_training_loop

--- a/docs/examples/continued_training.py
+++ b/docs/examples/continued_training.py
@@ -36,7 +36,7 @@ y += 0.01 * jr.normal(data_key, y.shape)  # Add some noise
 
 def metrics_factory():
     metric = klax.BatchMetric(
-        "training_loss",
+        "loss",
         klax.mse,
         (x, y),
         klax.batch_data,
@@ -120,7 +120,7 @@ for history, label in zip(
     [history_complete, history_continued, history_reset],
     ["Continuous training", "Continued training", "Reset optimizer state"],
 ):
-    history.plot("training_loss", ax=ax)
+    history.plot("loss", ax=ax)
     legend_labels.append("Loss - " + label)
 ax.legend(legend_labels)
 ax.set(

--- a/docs/examples/continued_training.py
+++ b/docs/examples/continued_training.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Continued trainig example.
+"""Continued training example.
 
 This example demonstrates how to continue a training session.
 It shows how to initialize the optax initializer state with a previous training session's final state,
@@ -34,20 +34,19 @@ y = 2 * x.sum(axis=-1) + 1.0
 y += 0.01 * jr.normal(data_key, y.shape)  # Add some noise
 
 
-def logger_factory():
-    logger = klax.MetricLogger(log_every=10)
-    logger.add_metric(
+def metrics_factory():
+    metric = klax.BatchMetric(
         "training_loss",
-        klax.Evaluator(
-            klax.mse,
-            (x, y),
-            klax.batch_data,
-            batch_size=x.shape[0],
-            batch_axes=0,
-            key=data_key,
-        ),
+        klax.mse,
+        (x, y),
+        klax.batch_data,
+        batch_size=x.shape[0],
+        batch_axes=0,
+        key=data_key,
     )
-    return logger
+    return [
+        metric,
+    ]
 
 
 # A: Complete training for 2000 steps
@@ -57,7 +56,8 @@ model, history_complete = klax.fit(
     (x, y),
     steps=2000,
     optimizer=optax.adabelief(1e-5),
-    logger=logger_factory(),
+    log_every=10,
+    metrics=metrics_factory(),
     key=train1_key,
 )
 
@@ -72,7 +72,8 @@ model, history_continued = klax.fit(
     (x, y),
     steps=100,
     optimizer=optax.adabelief(1e-5),
-    logger=logger_factory(),
+    log_every=10,
+    metrics=metrics_factory(),
     key=train1_key,
 )
 
@@ -82,7 +83,8 @@ model, history_continued_2 = klax.fit(
     steps=1900,
     optimizer=optax.adabelief(1e-5),  # (!) Same optimizer as in first session
     init_opt_state=history_continued.final_opt_state,  # Initialize the optimizer state with the last state
-    logger=logger_factory(),
+    log_every=10,
+    metrics=metrics_factory(),
     key=train2_key,
 )
 history_continued.extend(history_continued_2)
@@ -94,7 +96,8 @@ model, history_reset = klax.fit(
     (x, y),
     steps=100,
     optimizer=optax.adabelief(1e-5),
-    logger=logger_factory(),
+    log_every=10,
+    metrics=metrics_factory(),
     key=train1_key,
 )
 
@@ -104,7 +107,8 @@ model, history_reset_2 = klax.fit(
     steps=1900,
     optimizer=optax.adabelief(1e-5),  # (!) Same optimizer as in first session
     init_opt_state=None,  # No optimizer state is provided, so the optimizer is again initialized from scratch
-    logger=logger_factory(),
+    log_every=10,
+    metrics=metrics_factory(),
     key=train2_key,
 )
 history_reset.extend(history_reset_2)
@@ -112,11 +116,11 @@ history_reset.extend(history_reset_2)
 # D: Plot the recorded losses
 fig, ax = plt.subplots()
 legend_labels = []
-for histroy, label in zip(
+for history, label in zip(
     [history_complete, history_continued, history_reset],
     ["Continuous training", "Continued training", "Reset optimizer state"],
 ):
-    histroy.plot("training_loss", ax=ax)
+    history.plot("training_loss", ax=ax)
     legend_labels.append("Loss - " + label)
 ax.legend(legend_labels)
 ax.set(

--- a/klax/__init__.py
+++ b/klax/__init__.py
@@ -44,7 +44,7 @@ from ._training import run_training_loop as run_training_loop
 from ._trainstate import TrainingState as TrainingState
 from ._trainstate import TrainingStatic as TrainingStatic
 from ._trainstate import TrainingView as TrainingView
-from ._trainstate import make_state_and_static as make_state_and_static
+from ._trainstate import make_view as make_view
 from ._wrappers import Constraint as Constraint
 from ._wrappers import NonNegative as NonNegative
 from ._wrappers import NonTrainable as NonTrainable

--- a/klax/__init__.py
+++ b/klax/__init__.py
@@ -23,10 +23,11 @@ from ._initializers import SupportedInitializer as SupportedInitializer
 from ._initializers import canonicalize_initializer as canonicalize_initializer
 from ._initializers import hoedt_bias as hoedt_bias
 from ._initializers import hoedt_normal as hoedt_normal
-from ._logging import Evaluator as Evaluator
+from ._logging import BatchMetric as BatchMetric
 from ._logging import History as History
 from ._logging import Metric as Metric
 from ._logging import MetricLogger as MetricLogger
+from ._logging import metric as metric
 from ._losses import Loss as Loss
 from ._losses import loss as loss
 from ._losses import mae as mae
@@ -40,7 +41,7 @@ from ._serialization import (
 from ._tools import count_parameters as count_parameters
 from ._training import fit as fit
 from ._training import make_step as make_step
-from ._training import simple_fit as simple_fit
+from ._training import run_training_loop as run_training_loop
 from ._trainstate import TrainingState as TrainingState
 from ._trainstate import TrainingStatic as TrainingStatic
 from ._trainstate import TrainingView as TrainingView

--- a/klax/__init__.py
+++ b/klax/__init__.py
@@ -40,7 +40,7 @@ from ._serialization import (
 from ._tools import count_parameters as count_parameters
 from ._training import fit as fit
 from ._training import make_step as make_step
-from ._training import run_training_loop as run_training_loop
+from ._training import simple_fit as simple_fit
 from ._trainstate import TrainingState as TrainingState
 from ._trainstate import TrainingStatic as TrainingStatic
 from ._trainstate import TrainingView as TrainingView

--- a/klax/_logging.py
+++ b/klax/_logging.py
@@ -309,7 +309,7 @@ class MetricLogger(Callback):
 
     history: History
     log_every: int
-    metrics: list[Metric]
+    metrics: dict[str, Metric]
     steps_str_length: int = 0
     verbose: Literal[0, 1, 2]
     start_time: float = 0.0
@@ -328,6 +328,8 @@ class MetricLogger(Callback):
         Args:
             log_every: Frequency of logging metrics (in steps).
             metrics: Sequence of [metrics][klax.Metric] to evaluate.
+                If multiple metrics share the same name, the later metrics will
+                overwrite prior metrics.
             verbose: Verbosity level for logging metrics to the console. If 0,
                 no metrics will be printed. If 1, the metrics are printed. If
                 2, a progress bar will be shown.
@@ -335,7 +337,7 @@ class MetricLogger(Callback):
                 a new history object will be created.
 
         """
-        self.metrics = [] if metrics is None else list(metrics)
+        self.metrics = {} if metrics is None else {m.name: m for m in metrics}
         self.log_every = log_every
         self.history = History() if history is None else history
         self.verbose = verbose
@@ -348,11 +350,14 @@ class MetricLogger(Callback):
     def add_metric(self, metric: Metric) -> None:
         """Add a metric to be logged during training.
 
+        Warning:
+            Existing metrics sharing the same name will be overwritten.
+
         Args:
             metric: The metric to be added.
 
         """
-        self.metrics.append(metric)
+        self.metrics[metric.name] = metric
 
     def on_training_step(self, view: TrainingView, step: int) -> None:
         """Log metrics at the current training step.
@@ -364,7 +369,7 @@ class MetricLogger(Callback):
         """
         if step % self.log_every == 0:
             message = []
-            for metric in self.metrics:
+            for metric in self.metrics.values():
                 metric_value = jax.device_get(metric(view.model))
                 self.history.append(step, metric.name, metric_value)
                 if self.verbose and metric.verbose:

--- a/klax/_logging.py
+++ b/klax/_logging.py
@@ -18,7 +18,7 @@ import pickle
 from collections.abc import Callable
 from pathlib import Path
 from time import time
-from typing import Any, Protocol
+from typing import Any, Literal, Protocol
 
 import equinox as eqx
 import jax
@@ -286,9 +286,9 @@ class MetricLogger(Callback):
 
     history: History
     log_every: int
-    metric_defs: dict[str, (bool, Metric)]
+    metric_defs: dict[str, tuple[bool, Metric]]
     steps_str_length: int = 0
-    verbose: bool = True
+    verbose: Literal[0, 1, 2]
     start_time: float = 0.0
     progress_bar: bool
     tqdm_bar: Any = None
@@ -296,9 +296,9 @@ class MetricLogger(Callback):
     def __init__(
         self,
         log_every: int = 100,
-        metric_defs: dict[str, (bool, Metric)] | None = None,
-        verbose: bool = True,
-        progress_bar: bool = True,
+        metric_defs: dict[str, tuple[bool, Metric]] | None = None,
+        verbose: Literal[0, 1, 2] = 2,
+        history: History | None = None,
     ):
         """Initialize the MetricLogger.
 
@@ -306,18 +306,22 @@ class MetricLogger(Callback):
             log_every: Frequency of logging metrics (in steps).
             metric_defs: A dictionary mapping metric names to tuples of
                 (whether to print the metric, metric function).
-            verbose: Whether to print logged metrics to the console.
-            progress_bar: Whether to show a progress bar during training.
+            verbose: Verbosity level for logging metrics to the console. If 0,
+                no metrics will be printed. If 1, the metrics are printed. If
+                2, a progress bar will be shown.
+            history: An existing history object to log metrics to. If `None`,
+                a new history object will be created.
 
         """
         self.metric_defs = metric_defs or {}
         self.log_every = log_every
-        self.history = History()
+        self.history = history if history is not None else History()
         self.verbose = verbose
-        if progress_bar and not _TQDM_AVAILABLE:
-            print("Warning: tqdm not installed, progress bar disabled.")
-            progress_bar = False
-        self.progress_bar = progress_bar
+        if (verbose == 2) and not _TQDM_AVAILABLE:
+            print(
+                "Warning: tqdm for progress bar not installed. Changing verbosity level to 1."
+            )
+            self.verbose = 1
 
     def add_metric(
         self, name: str, metric: Metric, verbose: bool = False
@@ -354,7 +358,7 @@ class MetricLogger(Callback):
 
             if self.verbose:
                 postfix = ", ".join(message)
-                if self.progress_bar:
+                if self.verbose > 1:
                     self.tqdm_bar.set_postfix_str(postfix)
                     if step != 0:
                         self.tqdm_bar.update(self.log_every)
@@ -368,7 +372,7 @@ class MetricLogger(Callback):
         self.start_time = time()
         self.steps_str_length = len(str(view.static.steps))
 
-        if self.progress_bar:
+        if self.verbose > 1:
             self.tqdm_bar = tqdm(total=view.static.steps, dynamic_ncols=True)
 
         self.on_training_step(view, step)
@@ -379,5 +383,8 @@ class MetricLogger(Callback):
         self.history.total_steps = step
         self.history.final_opt_state = view.opt_state
 
-        if self.progress_bar:
-            self.tqdm_bar.close()
+        if self.verbose > 1:
+            try:
+                self.tqdm_bar.close()
+            except Exception as e:
+                pass

--- a/klax/_logging.py
+++ b/klax/_logging.py
@@ -387,16 +387,16 @@ class MetricLogger(Callback):
                         self.tqdm_bar.update(self.log_every)
                 else:
                     print(
-                        f"Step {step:>{self.steps_str_length}}/{view.static.steps}: "
+                        f"Step {step:>{self.steps_str_length}}/{view._static.steps}: "
                         + postfix
                     )
 
     def on_training_start(self, view: TrainingView, step: int) -> None:
         self.start_time = time()
-        self.steps_str_length = len(str(view.static.steps))
+        self.steps_str_length = len(str(view._static.steps))
 
         if self.verbose > 1:
-            self.tqdm_bar = tqdm(total=view.static.steps, dynamic_ncols=True)
+            self.tqdm_bar = tqdm(total=view._static.steps, dynamic_ncols=True)
 
         self.on_training_step(view, step)
 

--- a/klax/_logging.py
+++ b/klax/_logging.py
@@ -15,10 +15,12 @@
 """Utilities for logging during training."""
 
 import pickle
-from collections.abc import Callable
+from abc import ABC, abstractmethod
+from collections.abc import Callable, Sequence
+from functools import update_wrapper
 from pathlib import Path
 from time import time
-from typing import Any, Literal, Protocol
+from typing import Any, Literal, Protocol, cast
 
 import equinox as eqx
 import jax
@@ -40,12 +42,44 @@ except ImportError:
 
 
 class Metric(Protocol):
-    """A Metric is any object that can be called on a model and returns a value."""
+    """A Metric is any object that can be called on a model and returns a value.
+
+    Furthermore, metrics must have attributes `name: str` and `verbose: bool`.
+    """
+
+    name: str
+    verbose: bool
 
     def __call__(self, model: PyTree) -> Any: ...
 
 
-class Evaluator(Metric):
+def metric[T](
+    name: str, verbose: bool = False
+) -> Callable[[Callable[[PyTree], T]], Callable[[PyTree], T]]:
+    """Turn a function into a [Metric][klax.Metric] using a decorator factory.
+
+    Intended usage:
+    ```python
+    @metric(name="my_metric", verbose=False)
+    def compute_my_metric(model): ...
+    ```
+
+    Args:
+        name: Name of the metric.
+        verbose: Verbosity level for the metric. Defaults to False.
+
+    """
+
+    def make_metric(func):
+        func.name = name
+        func.verbose = verbose
+
+        return cast(Metric, func)
+
+    return make_metric
+
+
+class BatchMetric:
     """Compute a metric value from the model and a random batch of data.
 
     This is a convenience class that allows you to easily define metrics
@@ -57,6 +91,7 @@ class Evaluator(Metric):
 
     def __init__[T](
         self,
+        name: str,
         func: Callable[
             [PyTree[Any], PyTree[Any, "T"], PyTree[int | None, "T ..."]], Any  # type: ignore
         ],
@@ -64,21 +99,26 @@ class Evaluator(Metric):
         batcher: BatchGenerator,
         batch_size: int,
         batch_axes: PyTree[int | None, "T ..."] = 0,  # type: ignore
+        verbose: bool = False,
         *,
         key: PRNGKeyArray,
     ):
-        """Initialize the `Evaluator`.
+        """Initialize the `BatchMetric`.
 
         Args:
+            name: Name of the metric.
             func: The evaluation function to compute. It should take the model,
                 a batch of data, and the batch axes as input.
             data: The dataset to generate batches from.
             batcher: Batch generator function.
             batch_size: The size of each batch.
             batch_axes: The axes corresponding to the batch dimension in the data.
+            verbose: Verbosity level for the metric. Defaults to False.
             key: PRNG key for random number generation.
 
         """
+        self.name = name
+        self.verbose = verbose
         self.batch = batcher(data, batch_size, batch_axes, key=key)
         self.batch_axes = batch_axes
         self.func = func
@@ -248,7 +288,7 @@ class History:
         """Extend this history with the contents of another history.
 
         Args:
-            other: Another History instance to extend from.
+            other: Another History instance to extend with.
 
         """
         for key, (other_steps, other_values) in other.content.items():
@@ -265,28 +305,11 @@ class History:
 
 
 class MetricLogger(Callback):
-    """Callback for logging metrics in a History during training.
-
-    Example:
-        ```python
-            mylogger=MetricLogger(log_every=100)
-            mylogger.add_metric(
-                "accuracy",
-                lambda model: compute_accuracy(model)
-            )
-            model, history = fit(
-                model,
-                data,
-                ...,
-                logger=mylogger,
-            )
-        ```
-
-    """
+    """Callback for logging metrics in a History during training."""
 
     history: History
     log_every: int
-    metric_defs: dict[str, tuple[bool, Metric]]
+    metrics: list[Metric]
     steps_str_length: int = 0
     verbose: Literal[0, 1, 2]
     start_time: float = 0.0
@@ -296,7 +319,7 @@ class MetricLogger(Callback):
     def __init__(
         self,
         log_every: int = 100,
-        metric_defs: dict[str, tuple[bool, Metric]] | None = None,
+        metrics: Sequence[Metric] | None = None,
         verbose: Literal[0, 1, 2] = 2,
         history: History | None = None,
     ):
@@ -304,8 +327,7 @@ class MetricLogger(Callback):
 
         Args:
             log_every: Frequency of logging metrics (in steps).
-            metric_defs: A dictionary mapping metric names to tuples of
-                (whether to print the metric, metric function).
+            metrics: Sequence of [metrics][klax.Metric] to evaluate.
             verbose: Verbosity level for logging metrics to the console. If 0,
                 no metrics will be printed. If 1, the metrics are printed. If
                 2, a progress bar will be shown.
@@ -313,9 +335,9 @@ class MetricLogger(Callback):
                 a new history object will be created.
 
         """
-        self.metric_defs = metric_defs or {}
+        self.metrics = [] if metrics is None else list(metrics)
         self.log_every = log_every
-        self.history = history if history is not None else History()
+        self.history = History() if history is None else history
         self.verbose = verbose
         if (verbose == 2) and not _TQDM_AVAILABLE:
             print(
@@ -323,18 +345,14 @@ class MetricLogger(Callback):
             )
             self.verbose = 1
 
-    def add_metric(
-        self, name: str, metric: Metric, verbose: bool = False
-    ) -> None:
+    def add_metric(self, metric: Metric) -> None:
         """Add a metric to be logged during training.
 
         Args:
-            name: Name of the metric.
-            metric: A callable that computes the metric given the model.
-            verbose: Whether to print the metric during logging.
+            metric: The metric to be added.
 
         """
-        self.metric_defs[name] = (verbose, metric)
+        self.metrics.append(metric)
 
     def on_training_step(self, view: TrainingView, step: int) -> None:
         """Log metrics at the current training step.
@@ -346,15 +364,15 @@ class MetricLogger(Callback):
         """
         if step % self.log_every == 0:
             message = []
-            for name, (verbose, metric_fn) in self.metric_defs.items():
-                metric_value = jax.device_get(metric_fn(view.model))
-                self.history.append(step, name, metric_value)
-                if self.verbose and verbose:
+            for metric in self.metrics:
+                metric_value = jax.device_get(metric(view.model))
+                self.history.append(step, metric.name, metric_value)
+                if self.verbose and metric.verbose:
                     try:
                         formatted_value = f"{metric_value:.4e}"
                     except TypeError:
                         formatted_value = str(metric_value)
-                    message.append(f"{name}: {formatted_value}")
+                    message.append(f"{metric.name}: {formatted_value}")
 
             if self.verbose:
                 postfix = ", ".join(message)

--- a/klax/_training.py
+++ b/klax/_training.py
@@ -196,7 +196,7 @@ def fit[T: eqx.Module](
             (Defaults to `None`.)
         batcher: The data loader that splits inputs and targets into batches.
             (Defaults to `batch_data`.)
-        metrics: Sequence of [metrics][klax.Metric ] to be evaluated at regular
+        metrics: Sequence of [metrics][klax.Metric] to be evaluated at regular
             intervals during the training. You can overwrite the default "loss"
             and "validation_loss" metrics, by adding custom metrics with the same
             name.

--- a/klax/_training.py
+++ b/klax/_training.py
@@ -131,7 +131,7 @@ def run_training_loop(
     return view
 
 
-def fit[T: eqx.Module, H: History](
+def fit[T: eqx.Module](
     model: T,
     data: PyTree[Any],
     *,
@@ -145,12 +145,11 @@ def fit[T: eqx.Module, H: History](
     init_opt_state: PyTree[Any] = None,
     batcher: BatchGenerator = batch_data,
     metrics: Sequence[Metric] | None = None,
-    add_loss_metric: bool = True,
     log_every: int = 100,
     verbose: Literal[0, 1, 2] = 2,
     callbacks: Sequence[Callback] | None = None,
     key: PRNGKeyArray,
-) -> tuple[T, H]:
+) -> tuple[T, History]:
     """Train a model using an optimizer from optax.
 
     This is a convenient wrapper around [`firun_training_loopt`][klax.run_training_loop]
@@ -197,12 +196,11 @@ def fit[T: eqx.Module, H: History](
             (Defaults to `None`.)
         batcher: The data loader that splits inputs and targets into batches.
             (Defaults to `batch_data`.)
-        metrics: Sequence of [metrics][klax.Metric] to be evaluated at regular
-            intervals during the training. (Defaults to `None`.)
-        add_loss_metric: If `True` automatically adds a [BatchMetric][klax.BatchMetric]
-            for computing the training loss to the logger. Each time the metric
-            is evaluated, the loss is computed on a batch from the training dataset
-            (`data`) with batch size `batch_size`.
+        metrics: Sequence of [metrics][klax.Metric ] to be evaluated at regular
+            intervals during the training. You can overwrite the default "loss"
+            and "validation_loss" metrics, by adding custom metrics with the same
+            name.
+            (Defaults to `None`.)
         log_every: Interval for both metric evaluation and progress logging.
             A value `log_every=n` means that every `n` steps during the training
             the metrics are evaluated and (if `verbose>0`) the training progress
@@ -217,10 +215,6 @@ def fit[T: eqx.Module, H: History](
             (Defaults to `None`.)
         key: A `jax.random.PRNGKey` used to provide randomness for batch
             generation.
-
-    Note:
-        This function assumes that the batch dimension is always oriented along
-        the first axes of any `jax.Array`
 
     Returns:
         A tuple of the trained model and the loss history.
@@ -253,23 +247,22 @@ def fit[T: eqx.Module, H: History](
     # Make callbacks iterable
     callbacks = [] if callbacks is None else list(callbacks)
 
-    # Initialize callback arguments and history
-    metrics = [] if metrics is None else metrics
-    if add_loss_metric:
-        metrics.append(
-            BatchMetric(
-                "loss",
-                loss,
-                data,
-                batcher,
-                batch_size,
-                batch_axes,
-                verbose=True,
-                key=bkey,
-            )
+    # Initialize logging and default metrics
+    _metrics = []
+    _metrics.append(
+        BatchMetric(
+            "loss",
+            loss,
+            data,
+            batcher,
+            batch_size,
+            batch_axes,
+            verbose=True,
+            key=bkey,
         )
+    )
     if validation_data is not None:
-        metrics.append(
+        _metrics.append(
             BatchMetric(
                 "validation_loss",
                 loss,
@@ -281,7 +274,10 @@ def fit[T: eqx.Module, H: History](
                 key=bkey,
             ),
         )
-    logger = MetricLogger(log_every, metrics, verbose)
+    if metrics is not None:
+        _metrics += metrics
+    logger = MetricLogger(log_every, _metrics, verbose)
+
     callbacks.append(logger)
 
     view = run_training_loop(view, callbacks)

--- a/klax/_training.py
+++ b/klax/_training.py
@@ -112,8 +112,8 @@ def run_training_loop(
     for callback in callbacks:
         callback.on_training_start(view, step)
 
-    state = view.state
-    static = view.static
+    state = view._state
+    static = view._static
     for step in range(1, static.steps + 1):
         state = make_step(state, next(static.batch), static)
 
@@ -282,7 +282,7 @@ def fit[T: eqx.Module](
 
     view = run_training_loop(view, callbacks)
 
-    model = view.static.assemble_model(view.state.model_leaves)
+    model = view._static.assemble_model(view._state.model_leaves)
 
     history = logger.history if logger is not None else History()
 

--- a/klax/_training.py
+++ b/klax/_training.py
@@ -35,7 +35,7 @@ from ._trainstate import (
     TrainingState,
     TrainingStatic,
     TrainingView,
-    make_state_and_static,
+    make_view,
 )
 from ._wrappers import apply
 
@@ -95,26 +95,25 @@ def make_step(
 
 
 def run_training_loop(
-    state: TrainingState,
-    static: TrainingStatic,
+    view: TrainingView,
     callbacks: Iterable[Callback],
-) -> TrainingState:
+) -> TrainingView:
     """Iterate [`make_step`][klax.make_step] in pure python with callback integration.
 
     Args:
-        state: Initial [TrainingState][klax.TrainingState]
-        static: [TrainingStatic][klax.TrainingStatic]
+        view: [TrainingView][klax.TrainingView]
         callbacks: Iterable of [Callback][klax.Callback] instances.
 
     Returns:
-        Final [TrainingState][klax.TrainingState].
+        Final [TrainingView][klax.TrainingView].
 
     """
     step = 0
-    view = TrainingView(state, static)
     for callback in callbacks:
         callback.on_training_start(view, step)
 
+    state = view.state
+    static = view.static
     for step in range(1, static.steps + 1):
         state = make_step(state, next(static.batch), static)
 
@@ -128,7 +127,8 @@ def run_training_loop(
     for callback in callbacks:
         callback.on_training_end(view, step)
 
-    return state
+    view = TrainingView(state, static)
+    return view
 
 
 def fit[T: eqx.Module, H: Callback](
@@ -249,7 +249,7 @@ def fit[T: eqx.Module, H: Callback](
 
     bkey, key = jax.random.split(key)
     batch = batcher(data, batch_size, batch_axes, key=bkey)
-    state, static = make_state_and_static(
+    view = make_view(
         model,
         optimizer,
         opt_state,
@@ -289,9 +289,9 @@ def fit[T: eqx.Module, H: Callback](
             )
         callbacks.append(logger)
 
-    state = run_training_loop(state, static, callbacks)
+    view = run_training_loop(view, callbacks)
 
-    model = static.assemble_model(state.model_leaves)
+    model = view.static.assemble_model(view.state.model_leaves)
 
     history = logger.history if logger is not None else History()
 

--- a/klax/_training.py
+++ b/klax/_training.py
@@ -14,7 +14,7 @@
 
 """Implements a basic training loop."""
 
-from collections.abc import Iterable
+from collections.abc import Sequence
 from typing import Any, Literal
 
 import equinox as eqx
@@ -29,7 +29,7 @@ from ._datahandler import (
     BatchGenerator,
     batch_data,
 )
-from ._logging import Evaluator, History, Metric, MetricLogger
+from ._logging import BatchMetric, History, Metric, MetricLogger
 from ._losses import Loss, mse
 from ._trainstate import (
     TrainingState,
@@ -94,15 +94,15 @@ def make_step(
     )
 
 
-def fit(
+def run_training_loop(
     view: TrainingView,
-    callbacks: Iterable[Callback],
+    callbacks: Sequence[Callback],
 ) -> TrainingView:
     """Iterate [`make_step`][klax.make_step] in pure python with callback integration.
 
     Args:
         view: [TrainingView][klax.TrainingView]
-        callbacks: Iterable of [Callback][klax.Callback] instances.
+        callbacks: Sequence of [Callback][klax.Callback] instances.
 
     Returns:
         Final [TrainingView][klax.TrainingView].
@@ -131,7 +131,7 @@ def fit(
     return view
 
 
-def simple_fit[T: eqx.Module, H: History](
+def fit[T: eqx.Module, H: History](
     model: T,
     data: PyTree[Any],
     *,
@@ -144,16 +144,16 @@ def simple_fit[T: eqx.Module, H: History](
     | optax.GradientTransformationExtraArgs = optax.adam(1e-3),
     init_opt_state: PyTree[Any] = None,
     batcher: BatchGenerator = batch_data,
-    history: H | None = None,
-    metric_defs: dict[str, tuple[bool, Metric]] = {},
+    metrics: Sequence[Metric] | None = None,
+    add_loss_metric: bool = True,
     log_every: int = 100,
     verbose: Literal[0, 1, 2] = 2,
-    callbacks: Iterable[Callback] | None = None,
+    callbacks: Sequence[Callback] | None = None,
     key: PRNGKeyArray,
 ) -> tuple[T, H]:
     """Train a model using an optimizer from optax.
 
-    This is a convenient wrapper around [`fit`][klax.fit]
+    This is a convenient wrapper around [`firun_training_loopt`][klax.run_training_loop]
     that sets up optimizer, training state and callbacks.
 
     Args:
@@ -181,9 +181,9 @@ def simple_fit[T: eqx.Module, H: History](
         validation_data: Arbitrary `PyTree` used for validation during
             training. Must have the same tree structure as `data`. (Defaults
             to None.)
-            Internally, the validation data is used to create a [Evaluator][klax.Evaluator]
+            Internally, the validation data is used to create a [BatchMetric][klax.BatchMetric]
             for logging. Each time the metric is evaluated, the loss is computed
-            on a batch from the validation dataset and logged with batch size ``4*batch_size``.
+            on a batch from the validation dataset with batch size `4*batch_size`.
         steps: Number of gradient updates to apply. (Defaults to 1000.)
         loss: The loss function with call signature
             `(model: PyTree, data: PyTree, batch_axes: int | None |
@@ -197,12 +197,26 @@ def simple_fit[T: eqx.Module, H: History](
             (Defaults to `None`.)
         batcher: The data loader that splits inputs and targets into batches.
             (Defaults to `batch_data`.)
-        callbacks: Callback functions that are evaluated after every training
-            step. They can be used to implement early stopping, custom history
-            logging and more. The argument to the callback function is a
-            CallbackArgs object. (Defaults to `None`. Keyword only Argument)
+        metrics: Sequence of [metrics][klax.Metric] to be evaluated at regular
+            intervals during the training. (Defaults to `None`.)
+        add_loss_metric: If `True` automatically adds a [BatchMetric][klax.BatchMetric]
+            for computing the training loss to the logger. Each time the metric
+            is evaluated, the loss is computed on a batch from the training dataset
+            (`data`) with batch size `batch_size`.
+        log_every: Interval for both metric evaluation and progress logging.
+            A value `log_every=n` means that every `n` steps during the training
+            the metrics are evaluated and (if `verbose>0`) the training progress
+            and selected metric values are printed.
+        verbose: Integer controlling the verbosity during training.
+            - 0: Nothing is printed.
+            - 1: A message is printed every `log_every` steps.
+            - 2: A progressbar is used and updated every `log_every` steps.
+        callbacks: List of [Callbacks][klax.Callback]. They can be used to
+            implement early stopping, custom logging and more. The argument
+            to the callback function is aCallbackArgs object.
+            (Defaults to `None`.)
         key: A `jax.random.PRNGKey` used to provide randomness for batch
-            generation. (Keyword only argument.)
+            generation.
 
     Note:
         This function assumes that the batch dimension is always oriented along
@@ -240,26 +254,37 @@ def simple_fit[T: eqx.Module, H: History](
     callbacks = [] if callbacks is None else list(callbacks)
 
     # Initialize callback arguments and history
-    metric_defs["loss"] = (
-        True,
-        Evaluator(loss, data, batcher, batch_size, batch_axes, key=bkey),
-    )
+    metrics = [] if metrics is None else metrics
+    if add_loss_metric:
+        metrics.append(
+            BatchMetric(
+                "loss",
+                loss,
+                data,
+                batcher,
+                batch_size,
+                batch_axes,
+                verbose=True,
+                key=bkey,
+            )
+        )
     if validation_data is not None:
-        metric_defs["validation_loss"] = (
-            True,
-            Evaluator(
+        metrics.append(
+            BatchMetric(
+                "validation_loss",
                 loss,
                 validation_data,
                 batcher,
                 4 * batch_size,
                 batch_axes,
+                verbose=True,
                 key=bkey,
             ),
         )
-    logger = MetricLogger(log_every, metric_defs, verbose, history=history)
+    logger = MetricLogger(log_every, metrics, verbose)
     callbacks.append(logger)
 
-    view = fit(view, callbacks)
+    view = run_training_loop(view, callbacks)
 
     model = view.static.assemble_model(view.state.model_leaves)
 

--- a/klax/_training.py
+++ b/klax/_training.py
@@ -15,7 +15,7 @@
 """Implements a basic training loop."""
 
 from collections.abc import Iterable
-from typing import Any
+from typing import Any, Literal
 
 import equinox as eqx
 import jax
@@ -29,7 +29,7 @@ from ._datahandler import (
     BatchGenerator,
     batch_data,
 )
-from ._logging import Evaluator, History, MetricLogger
+from ._logging import Evaluator, History, Metric, MetricLogger
 from ._losses import Loss, mse
 from ._trainstate import (
     TrainingState,
@@ -94,7 +94,7 @@ def make_step(
     )
 
 
-def run_training_loop(
+def fit(
     view: TrainingView,
     callbacks: Iterable[Callback],
 ) -> TrainingView:
@@ -131,7 +131,7 @@ def run_training_loop(
     return view
 
 
-def fit[T: eqx.Module, H: Callback](
+def simple_fit[T: eqx.Module, H: History](
     model: T,
     data: PyTree[Any],
     *,
@@ -144,13 +144,16 @@ def fit[T: eqx.Module, H: Callback](
     | optax.GradientTransformationExtraArgs = optax.adam(1e-3),
     init_opt_state: PyTree[Any] = None,
     batcher: BatchGenerator = batch_data,
-    logger: MetricLogger | None = new_logger,
+    history: H | None = None,
+    metric_defs: dict[str, tuple[bool, Metric]] = {},
+    log_every: int = 100,
+    verbose: Literal[0, 1, 2] = 2,
     callbacks: Iterable[Callback] | None = None,
     key: PRNGKeyArray,
-) -> tuple[T, History]:
+) -> tuple[T, H]:
     """Train a model using an optimizer from optax.
 
-    This is a convenient wrapper around [`run_training_loop`][klax.run_training_loop]
+    This is a convenient wrapper around [`fit`][klax.fit]
     that sets up optimizer, training state and callbacks.
 
     Args:
@@ -194,32 +197,6 @@ def fit[T: eqx.Module, H: Callback](
             (Defaults to `None`.)
         batcher: The data loader that splits inputs and targets into batches.
             (Defaults to `batch_data`.)
-        logger: A callback intended for tracking the training process. If no
-            custom MetricLogger instance is passed the [`klax.MetricLogger`][]
-            with a logging interval of 100 steps is used. To change the logging
-            increment or verbosity of this default callback, pass a
-            `MetricLogger` object to this argument, e.g.,
-            `logger=MetricLogger(log_every=10, verbose=False)` for logging
-            on every 10-th step without printing the loss. This can also be used
-            to log additional metrics during training, e.g.,
-            ```python
-                mylogger=MetricLogger(log_every=100)
-                mylogger.add_metric(
-                    "accuracy",
-                    lambda model: compute_accuracy(model)
-                )
-                model, history = fit(
-                    model,
-                    data,
-                    ...,
-                    logger=mylogger,
-                )
-            ```
-            Any passed [`klax.MetricLogger`][] will have a training
-            [Evaluator][klax.Evaluator] and - if applicable - a validation
-            [Evaluator][klax.Evaluator] added automatically. If this is undesired,
-            set `logger=None` and pass your logger as a callback via the
-            `callbacks` argument. (Per default a new MetricLogger instance is created.)
         callbacks: Callback functions that are evaluated after every training
             step. They can be used to implement early stopping, custom history
             logging and more. The argument to the callback function is a
@@ -263,33 +240,26 @@ def fit[T: eqx.Module, H: Callback](
     callbacks = [] if callbacks is None else list(callbacks)
 
     # Initialize callback arguments and history
-    if logger is not None:
-        logger = MetricLogger() if logger is new_logger else logger
-
-        bkey, key = jax.random.split(key)
-        logger.add_metric(
-            "loss",
-            Evaluator(loss, data, batcher, batch_size, batch_axes, key=bkey),
-            verbose=True,
+    metric_defs["loss"] = (
+        True,
+        Evaluator(loss, data, batcher, batch_size, batch_axes, key=bkey),
+    )
+    if validation_data is not None:
+        metric_defs["validation_loss"] = (
+            True,
+            Evaluator(
+                loss,
+                validation_data,
+                batcher,
+                4 * batch_size,
+                batch_axes,
+                key=bkey,
+            ),
         )
+    logger = MetricLogger(log_every, metric_defs, verbose, history=history)
+    callbacks.append(logger)
 
-        if validation_data is not None:
-            bkey, key = jax.random.split(key)
-            logger.add_metric(
-                "validation_loss",
-                Evaluator(
-                    loss,
-                    validation_data,
-                    batcher,
-                    4 * batch_size,
-                    batch_axes,
-                    key=bkey,
-                ),
-                verbose=True,
-            )
-        callbacks.append(logger)
-
-    view = run_training_loop(view, callbacks)
+    view = fit(view, callbacks)
 
     model = view.static.assemble_model(view.state.model_leaves)
 

--- a/klax/_trainstate.py
+++ b/klax/_trainstate.py
@@ -14,13 +14,17 @@
 
 from collections.abc import Generator
 from dataclasses import dataclass
-from typing import Any, Self
+from typing import Any
 
 import jax
 import optax
 from jaxtyping import PyTree, PyTreeDef
 
 from klax._losses import Loss
+
+# ====--------------------------------------------------------------------=== #
+# TrainingView classes
+# ====--------------------------------------------------------------------=== #
 
 
 @jax.tree_util.register_dataclass
@@ -75,58 +79,6 @@ class TrainingStatic:
         return leaves
 
 
-def make_state_and_static(
-    model: PyTree[Any],
-    optimizer: optax.GradientTransformation
-    | optax.GradientTransformationExtraArgs,
-    opt_state: PyTree[Any],
-    batch: Generator[PyTree[Any], None, None],
-    batch_axes: PyTree[int | None],
-    loss: Loss,
-    steps: int,
-) -> tuple[TrainingState, TrainingStatic]:
-    """Create the initial TrainingState and TrainingStatic from the model and optimizer.
-
-    Args:
-        model: The initial model parameters.
-        optimizer: The optimizer to use for training.
-        opt_state: The initial optimizer state.
-        batch: A generator that yields batches of data.
-        batch_axes: A PyTree indicating the batch axes for each component of the data.
-        loss: The loss function to use for training.
-        steps: The total number of training steps.
-
-    Returns:
-        A tuple of (TrainingState, TrainingStatic).
-
-    """
-    model_leaves, model_treedef = jax.tree.flatten(model)
-    opt_state_leaves, opt_state_treedef = jax.tree.flatten(opt_state)
-
-    optimizer = (
-        optax.with_extra_args_support(optimizer)
-        if not isinstance(optimizer, optax.GradientTransformationExtraArgs)
-        else optimizer
-    )
-
-    state = TrainingState(
-        model_leaves=model_leaves,
-        opt_state_leaves=opt_state_leaves,
-    )
-
-    static = TrainingStatic(
-        model_tree_def=model_treedef,
-        optimizer=optimizer,
-        opt_state_tree_def=opt_state_treedef,
-        batch=batch,
-        batch_axes=batch_axes,
-        loss=loss,
-        steps=steps,
-    )
-
-    return state, static
-
-
 # This is similar to the old CallbackArgs, but ensures a clean separation
 # between mutable state (TrainingState) and static components (TrainingStatic),
 # while providing a nice public-facing interface to access and modify the model
@@ -179,3 +131,60 @@ class TrainingView:
     def opt_state(self, value):
         self.state.opt_state_leaves = self.static.disassemble_opt_state(value)
         self._opt_state = value
+
+
+# ====--------------------------------------------------------------------=== #
+# Factory methods
+# ====--------------------------------------------------------------------=== #
+
+
+def make_view(
+    model: PyTree[Any],
+    optimizer: optax.GradientTransformation
+    | optax.GradientTransformationExtraArgs,
+    opt_state: PyTree[Any],
+    batch: Generator[PyTree[Any], None, None],
+    batch_axes: PyTree[int | None],
+    loss: Loss,
+    steps: int,
+) -> TrainingView:
+    """Create the TrainingView from the model and optimizer.
+
+    Args:
+        model: The initial model parameters.
+        optimizer: The optimizer to use for training.
+        opt_state: The initial optimizer state.
+        batch: A generator that yields batches of data.
+        batch_axes: A PyTree indicating the batch axes for each component of the data.
+        loss: The loss function to use for training.
+        steps: The total number of training steps.
+
+    Returns:
+        A TrainingView.
+
+    """
+    model_leaves, model_treedef = jax.tree.flatten(model)
+    opt_state_leaves, opt_state_treedef = jax.tree.flatten(opt_state)
+
+    optimizer = (
+        optax.with_extra_args_support(optimizer)
+        if not isinstance(optimizer, optax.GradientTransformationExtraArgs)
+        else optimizer
+    )
+
+    state = TrainingState(
+        model_leaves=model_leaves,
+        opt_state_leaves=opt_state_leaves,
+    )
+
+    static = TrainingStatic(
+        model_tree_def=model_treedef,
+        optimizer=optimizer,
+        opt_state_tree_def=opt_state_treedef,
+        batch=batch,
+        batch_axes=batch_axes,
+        loss=loss,
+        steps=steps,
+    )
+
+    return TrainingView(state, static)

--- a/klax/_trainstate.py
+++ b/klax/_trainstate.py
@@ -95,14 +95,14 @@ class TrainingView:
 
     """
 
-    state: TrainingState
-    static: TrainingStatic
+    _state: TrainingState
+    _static: TrainingStatic
     _model: Any  # Cached model instance.
     _opt_state: Any  # Cached optimizer state.
 
     def __init__(self, state: TrainingState, static: TrainingStatic):
-        self.state = state
-        self.static = static
+        self._state = state
+        self._static = static
         self._model = None
         self._opt_state = None
 
@@ -110,27 +110,57 @@ class TrainingView:
     def model(self):
         """Accessor for the model instance."""
         if self._model is None:
-            self._model = self.static.assemble_model(self.state.model_leaves)
+            self._model = self._static.assemble_model(self._state.model_leaves)
         return self._model
 
     @model.setter
     def model(self, value):
-        self.state.model_leaves = self.static.disassemble_model(value)
+        self._state.model_leaves = self._static.disassemble_model(value)
         self._model = value
 
     @property
     def opt_state(self):
         """Accessor for the optimizer state."""
         if self._opt_state is None:
-            self._opt_state = self.static.assemble_opt_state(
-                self.state.opt_state_leaves
+            self._opt_state = self._static.assemble_opt_state(
+                self._state.opt_state_leaves
             )
         return self._opt_state
 
     @opt_state.setter
     def opt_state(self, value):
-        self.state.opt_state_leaves = self.static.disassemble_opt_state(value)
+        self._state.opt_state_leaves = self._static.disassemble_opt_state(
+            value
+        )
         self._opt_state = value
+
+    @property
+    def model_tree_def(self) -> PyTreeDef:  # pyright: ignore[reportInvalidTypeForm]
+        return self._static.model_tree_def
+
+    @property
+    def optimizer(self) -> optax.GradientTransformationExtraArgs:
+        return self._static.optimizer
+
+    @property
+    def opt_state_tree_def(self) -> PyTreeDef:  # pyright: ignore[reportInvalidTypeForm]
+        return self._static.opt_state_tree_def
+
+    @property
+    def batch(self) -> Generator[PyTree[Any], None, None]:
+        return self._static.batch
+
+    @property
+    def batch_axes(self) -> PyTree[int | None]:
+        return self._static.batch_axes
+
+    @property
+    def loss(self) -> Loss:
+        return self._static.loss
+
+    @property
+    def steps(self) -> int:
+        return self._static.steps
 
 
 # ====--------------------------------------------------------------------=== #

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -251,7 +251,7 @@ class TestMetricLogger:
     ):
         return SimpleNamespace(
             model=model if model is not None else {"w": 1.0},
-            static=SimpleNamespace(steps=steps),
+            _static=SimpleNamespace(steps=steps),
             opt_state=opt_state if opt_state is not None else {"opt": 1},
         )
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -6,7 +6,7 @@ import jax.random as jr
 import pytest
 
 import klax
-from klax import Evaluator, History, MetricLogger
+from klax import Evaluator, History, MetricLogger, TrainingView
 
 
 class TestEvaluator:
@@ -237,8 +237,8 @@ class TestMetricLogger:
         )
 
     def test_add_metric_and_logging_frequency(self):
-        logger = MetricLogger(log_every=2, verbose=False)
-        logger.add_metric("m1", lambda model: jnp.array(1.0), verbose=False)
+        metric_defs = {"m1": (False, lambda model: jnp.array(1.0))}
+        logger = MetricLogger(log_every=2, metric_defs=metric_defs, verbose=0)
 
         view = self._make_view(steps=10)
 
@@ -256,7 +256,7 @@ class TestMetricLogger:
         assert logger.history.content["m1"][0] == [2, 4]
 
     def test_verbose_print_scalar_metric(self, capsys):
-        logger = MetricLogger(log_every=1, verbose=True, progress_bar=False)
+        logger = MetricLogger(log_every=1, verbose=1)
         logger.add_metric("loss", lambda model: jnp.array(1.23), verbose=True)
 
         view = self._make_view(steps=10)
@@ -268,7 +268,7 @@ class TestMetricLogger:
         assert "loss: 1.2300e+00" in out
 
     def test_verbose_print_non_scalar_metric(self, capsys):
-        logger = MetricLogger(log_every=1, verbose=True, progress_bar=False)
+        logger = MetricLogger(log_every=1, verbose=1)
         logger.add_metric(
             "arr", lambda model: jnp.array([1.0, 2.0]), verbose=True
         )
@@ -282,7 +282,7 @@ class TestMetricLogger:
         assert "arr:" in out
 
     def test_on_training_start_and_end_sets_history(self):
-        logger = MetricLogger(log_every=1, verbose=False)
+        logger = MetricLogger(log_every=1, verbose=0)
         logger.add_metric("m", lambda model: jnp.array(0.0), verbose=False)
 
         sentinel_opt = {"state": 42}
@@ -300,7 +300,7 @@ class TestMetricLogger:
         assert logger.history.final_opt_state is sentinel_opt
 
     def test_add_metric_registers_with_verbose_flag(self):
-        logger = MetricLogger(log_every=10, verbose=False)
+        logger = MetricLogger(log_every=10, verbose=0)
         logger.add_metric("acc", lambda model: jnp.array(0.9), verbose=True)
 
         assert "acc" in logger.metric_defs

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -6,14 +6,28 @@ import jax.random as jr
 import pytest
 
 import klax
-from klax import Evaluator, History, MetricLogger, TrainingView
+from klax import BatchMetric, History, MetricLogger, TrainingView
 
 
-class TestEvaluator:
-    """Test suite for the Evaluator class."""
+class TestMetricDecorator:
+    """Test the metric decorator."""
+
+    def test_attributes(self):
+        @klax.metric(name="my_metric", verbose=True)
+        def some_func(model):
+            """My docstring."""
+            return jnp.zeros(())
+
+        assert some_func.name == "my_metric"
+        assert some_func.verbose
+        assert some_func.__doc__ == """My docstring."""
+
+
+class TestBatchMetric:
+    """Test suite for the BatchMetric class."""
 
     def test_initialization(self, getkey):
-        """Test Evaluator initialization with required parameters."""
+        """Test BatchMetric initialization with required parameters."""
         data = (
             jr.uniform(getkey(), (100, 2)),
             jr.uniform(getkey(), (100, 1)),
@@ -21,17 +35,21 @@ class TestEvaluator:
         batch_size = 32
         batch_axes = 0
 
-        metric = Evaluator(
+        metric = BatchMetric(
+            name="my_metric",
             func=klax.mse,
             data=data,
             batcher=klax.batch_data,
             batch_size=batch_size,
             batch_axes=batch_axes,
+            verbose=False,
             key=getkey(),
         )
 
+        assert metric.name == "my_metric"
         assert metric.batch_axes == batch_axes
         assert metric.func == klax.mse
+        assert not metric.verbose
 
     def test_call(self, getkey):
         """Test __call__ method."""
@@ -42,7 +60,8 @@ class TestEvaluator:
         batch_size = 32
         batch_axes = 0
 
-        metric = Evaluator(
+        metric = BatchMetric(
+            name="my_metric",
             func=klax.mse,
             data=data,
             batcher=klax.batch_data,
@@ -237,8 +256,14 @@ class TestMetricLogger:
         )
 
     def test_add_metric_and_logging_frequency(self):
-        metric_defs = {"m1": (False, lambda model: jnp.array(1.0))}
-        logger = MetricLogger(log_every=2, metric_defs=metric_defs, verbose=0)
+        my_metric = klax.metric(name="m1")(lambda model: jnp.array(1.0))
+        logger = MetricLogger(
+            log_every=2,
+            metrics=[
+                my_metric,
+            ],
+            verbose=0,
+        )
 
         view = self._make_view(steps=10)
 
@@ -257,7 +282,10 @@ class TestMetricLogger:
 
     def test_verbose_print_scalar_metric(self, capsys):
         logger = MetricLogger(log_every=1, verbose=1)
-        logger.add_metric("loss", lambda model: jnp.array(1.23), verbose=True)
+        my_metric = klax.metric(name="loss", verbose=True)(
+            lambda model: jnp.array(1.23)
+        )
+        logger.add_metric(my_metric)
 
         view = self._make_view(steps=10)
         logger.on_training_step(view, 0)
@@ -269,9 +297,11 @@ class TestMetricLogger:
 
     def test_verbose_print_non_scalar_metric(self, capsys):
         logger = MetricLogger(log_every=1, verbose=1)
-        logger.add_metric(
-            "arr", lambda model: jnp.array([1.0, 2.0]), verbose=True
+
+        my_metric = klax.metric(name="arr", verbose=True)(
+            lambda model: jnp.array([1.0, 2.0])
         )
+        logger.add_metric(my_metric)
 
         view = self._make_view(steps=5)
         logger.on_training_step(view, 0)
@@ -283,7 +313,11 @@ class TestMetricLogger:
 
     def test_on_training_start_and_end_sets_history(self):
         logger = MetricLogger(log_every=1, verbose=0)
-        logger.add_metric("m", lambda model: jnp.array(0.0), verbose=False)
+
+        my_metric = klax.metric(name="m", verbose=False)(
+            lambda model: jnp.array(0.0)
+        )
+        logger.add_metric(my_metric)
 
         sentinel_opt = {"state": 42}
         view = self._make_view(steps=7, opt_state=sentinel_opt)
@@ -298,12 +332,3 @@ class TestMetricLogger:
         assert isinstance(logger.history.total_time, float)
         assert logger.history.total_time >= 0.0
         assert logger.history.final_opt_state is sentinel_opt
-
-    def test_add_metric_registers_with_verbose_flag(self):
-        logger = MetricLogger(log_every=10, verbose=0)
-        logger.add_metric("acc", lambda model: jnp.array(0.9), verbose=True)
-
-        assert "acc" in logger.metric_defs
-        verbose_flag, metric_fn = logger.metric_defs["acc"]
-        assert verbose_flag is True
-        assert callable(metric_fn)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -332,3 +332,24 @@ class TestMetricLogger:
         assert isinstance(logger.history.total_time, float)
         assert logger.history.total_time >= 0.0
         assert logger.history.final_opt_state is sentinel_opt
+
+    def test_logger_overwrites_metric(self):
+        """The logger should overwrite metrics with the same name."""
+        metric_a = klax.metric(name="loss", verbose=False)(lambda model: "A")
+
+        metric_b = klax.metric(name="loss", verbose=False)(lambda model: "B")
+
+        logger = MetricLogger(
+            log_every=1, metrics=[metric_a, metric_b], verbose=0
+        )
+        assert len(logger.metrics) == 1
+
+        sentinel_opt = {"state": 42}
+        view = self._make_view(steps=7, opt_state=sentinel_opt)
+        logger.on_training_start(view, 0)
+        assert logger.history.content["loss"][1] == ["B"]
+
+        logger.add_metric(metric_a)
+        logger.on_training_step(view, 1)
+
+        assert logger.history.content["loss"][1] == ["B", "A"]

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -227,28 +227,57 @@ class TestRunTrainingLoop:
         )
 
 
-def test_fit(getkey):
-    model = klax.nn.FICNN(2, "scalar", [4, 4], key=getkey())
+class TestFit:
+    def test_basic_behavior(self, getkey):
+        model = klax.nn.FICNN(2, "scalar", [4, 4], key=getkey())
 
-    data = (
-        jr.uniform(getkey(), (100, 2)),
-        jr.uniform(getkey(), (100,)),
-    )
+        data = (
+            jr.uniform(getkey(), (100, 2)),
+            jr.uniform(getkey(), (100,)),
+        )
 
-    trained_model, history = klax.fit(
-        model,
-        data,
-        batch_size=5,
-        batch_axes=0,
-        steps=5,
-        loss=klax.mse,
-        optimizer=optax.sgd(0.1),
-        key=getkey(),
-    )
+        trained_model, history = klax.fit(
+            model,
+            data,
+            batch_size=5,
+            batch_axes=0,
+            steps=5,
+            loss=klax.mse,
+            optimizer=optax.sgd(0.1),
+            key=getkey(),
+        )
 
-    assert isinstance(trained_model, klax.nn.FICNN)
-    assert history.total_steps == 5
-    assert "loss" in history.content
-    loss_steps, loss_values = history["loss"]
-    assert loss_steps == [0]
-    assert len(loss_values) == 1
+        assert isinstance(trained_model, klax.nn.FICNN)
+        assert history.total_steps == 5
+        assert "loss" in history.content
+        loss_steps, loss_values = history["loss"]
+        assert loss_steps == [0]
+        assert len(loss_values) == 1
+
+    def test_overwriting_default_metrics(self, getkey):
+        model = klax.nn.FICNN(2, "scalar", [4, 4], key=getkey())
+
+        data = (
+            jr.uniform(getkey(), (100, 2)),
+            jr.uniform(getkey(), (100,)),
+        )
+
+        def my_metric(model):
+            return "A"
+
+        my_metric.name = "loss"
+        my_metric.verbose = False
+
+        trained_model, history = klax.fit(
+            model,
+            data,
+            batch_size=5,
+            batch_axes=0,
+            steps=5,
+            loss=klax.mse,
+            optimizer=optax.sgd(0.1),
+            metrics=[my_metric],
+            key=getkey(),
+        )
+
+        assert history.content["loss"][1] == ["A"]

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -76,8 +76,8 @@ class TestMakeStep:
         )
 
 
-class TestFit:
-    def test_fit_invokes_callbacks(self, getkey):
+class TestRunTrainingLoop:
+    def test_invokes_callbacks(self, getkey):
         class RecordingCallback(klax.Callback):
             def __init__(self):
                 self.start_steps = []
@@ -113,7 +113,7 @@ class TestFit:
 
         callback = RecordingCallback()
 
-        updated_view = klax.fit(view, [callback])
+        updated_view = klax.run_training_loop(view, [callback])
 
         assert callback.start_steps == [0]
         assert callback.steps == [1, 2, 3]
@@ -128,7 +128,7 @@ class TestFit:
             )
         )
 
-    def test_fit_zero_steps_no_updates(self, getkey):
+    def test_zero_steps_no_updates(self, getkey):
         class RecordingCallback(klax.Callback):
             def __init__(self):
                 self.start_steps = []
@@ -164,7 +164,7 @@ class TestFit:
 
         callback = RecordingCallback()
 
-        updated_view = klax.fit(view, [callback])
+        updated_view = klax.run_training_loop(view, [callback])
 
         assert callback.start_steps == [0]
         assert callback.steps == []
@@ -179,7 +179,7 @@ class TestFit:
             )
         )
 
-    def test_fit_stops_on_callback(self, getkey):
+    def test_stops_on_callback(self, getkey):
         class StopAfterOne(klax.Callback):
             def __init__(self):
                 self.steps = []
@@ -212,7 +212,7 @@ class TestFit:
 
         callback = StopAfterOne()
 
-        updated_view = klax.fit(view, [callback])
+        updated_view = klax.run_training_loop(view, [callback])
 
         assert callback.steps == [1]
         assert callback.end_steps == [1]
@@ -227,7 +227,7 @@ class TestFit:
         )
 
 
-def test_simple_fit(getkey):
+def test_fit(getkey):
     model = klax.nn.FICNN(2, "scalar", [4, 4], key=getkey())
 
     data = (
@@ -235,7 +235,7 @@ def test_simple_fit(getkey):
         jr.uniform(getkey(), (100,)),
     )
 
-    trained_model, history = klax.simple_fit(
+    trained_model, history = klax.fit(
         model,
         data,
         batch_size=5,

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -50,7 +50,7 @@ class TestMakeStep:
         y = jnp.array([3.0, 7.0])
         batch = klax.batch_data((x, y), batch_size=32, key=getkey())
 
-        state, static = klax.make_state_and_static(
+        view = klax.make_view(
             model=model,
             optimizer=optimizer,
             opt_state=opt_state,
@@ -60,7 +60,9 @@ class TestMakeStep:
             steps=5,
         )
 
-        new_state = klax.make_step(state, next(static.batch), static)
+        new_state = klax.make_step(
+            view.state, next(view.static.batch), view.static
+        )
 
         # State has changed
         assert not jax.tree.all(
@@ -68,7 +70,7 @@ class TestMakeStep:
                 lambda a, b: jnp.array_equal(a, b)
                 if isinstance(a, jnp.ndarray)
                 else a == b,
-                state.model_leaves,
+                view.state.model_leaves,
                 new_state.model_leaves,
             )
         )
@@ -99,7 +101,7 @@ class TestRunTrainingLoop:
         y = jnp.array([3.0, 7.0])
         batch = klax.batch_data((x, y), batch_size=32, key=getkey())
 
-        state, static = klax.make_state_and_static(
+        view = klax.make_view(
             model=model,
             optimizer=optimizer,
             opt_state=opt_state,
@@ -111,7 +113,7 @@ class TestRunTrainingLoop:
 
         callback = RecordingCallback()
 
-        new_state = klax.run_training_loop(state, static, [callback])
+        updated_view = klax.run_training_loop(view, [callback])
 
         assert callback.start_steps == [0]
         assert callback.steps == [1, 2, 3]
@@ -121,8 +123,8 @@ class TestRunTrainingLoop:
                 lambda a, b: jnp.array_equal(a, b)
                 if isinstance(a, jnp.ndarray)
                 else a == b,
-                state.model_leaves,
-                new_state.model_leaves,
+                view.state.model_leaves,
+                updated_view.state.model_leaves,
             )
         )
 
@@ -150,7 +152,7 @@ class TestRunTrainingLoop:
         y = jnp.array([3.0, 7.0])
         batch = klax.batch_data((x, y), batch_size=32, key=getkey())
 
-        state, static = klax.make_state_and_static(
+        view = klax.make_view(
             model=model,
             optimizer=optimizer,
             opt_state=opt_state,
@@ -162,7 +164,7 @@ class TestRunTrainingLoop:
 
         callback = RecordingCallback()
 
-        new_state = klax.run_training_loop(state, static, [callback])
+        updated_view = klax.run_training_loop(view, [callback])
 
         assert callback.start_steps == [0]
         assert callback.steps == []
@@ -172,8 +174,8 @@ class TestRunTrainingLoop:
                 lambda a, b: jnp.array_equal(a, b)
                 if isinstance(a, jnp.ndarray)
                 else a == b,
-                state.model_leaves,
-                new_state.model_leaves,
+                view.state.model_leaves,
+                updated_view.state.model_leaves,
             )
         )
 
@@ -198,7 +200,7 @@ class TestRunTrainingLoop:
         y = jnp.array([3.0, 7.0])
         batch = klax.batch_data((x, y), batch_size=32, key=getkey())
 
-        state, static = klax.make_state_and_static(
+        view = klax.make_view(
             model=model,
             optimizer=optimizer,
             opt_state=opt_state,
@@ -210,7 +212,7 @@ class TestRunTrainingLoop:
 
         callback = StopAfterOne()
 
-        new_state = klax.run_training_loop(state, static, [callback])
+        updated_view = klax.run_training_loop(view, [callback])
 
         assert callback.steps == [1]
         assert callback.end_steps == [1]
@@ -219,8 +221,8 @@ class TestRunTrainingLoop:
                 lambda a, b: jnp.array_equal(a, b)
                 if isinstance(a, jnp.ndarray)
                 else a == b,
-                state.model_leaves,
-                new_state.model_leaves,
+                view.state.model_leaves,
+                updated_view.state.model_leaves,
             )
         )
 

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -61,7 +61,7 @@ class TestMakeStep:
         )
 
         new_state = klax.make_step(
-            view.state, next(view.static.batch), view.static
+            view._state, next(view._static.batch), view._static
         )
 
         # State has changed
@@ -70,7 +70,7 @@ class TestMakeStep:
                 lambda a, b: jnp.array_equal(a, b)
                 if isinstance(a, jnp.ndarray)
                 else a == b,
-                view.state.model_leaves,
+                view._state.model_leaves,
                 new_state.model_leaves,
             )
         )
@@ -123,8 +123,8 @@ class TestRunTrainingLoop:
                 lambda a, b: jnp.array_equal(a, b)
                 if isinstance(a, jnp.ndarray)
                 else a == b,
-                view.state.model_leaves,
-                updated_view.state.model_leaves,
+                view._state.model_leaves,
+                updated_view._state.model_leaves,
             )
         )
 
@@ -174,8 +174,8 @@ class TestRunTrainingLoop:
                 lambda a, b: jnp.array_equal(a, b)
                 if isinstance(a, jnp.ndarray)
                 else a == b,
-                view.state.model_leaves,
-                updated_view.state.model_leaves,
+                view._state.model_leaves,
+                updated_view._state.model_leaves,
             )
         )
 
@@ -221,8 +221,8 @@ class TestRunTrainingLoop:
                 lambda a, b: jnp.array_equal(a, b)
                 if isinstance(a, jnp.ndarray)
                 else a == b,
-                view.state.model_leaves,
-                updated_view.state.model_leaves,
+                view._state.model_leaves,
+                updated_view._state.model_leaves,
             )
         )
 

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -76,8 +76,8 @@ class TestMakeStep:
         )
 
 
-class TestRunTrainingLoop:
-    def test_run_training_loop_invokes_callbacks(self, getkey):
+class TestFit:
+    def test_fit_invokes_callbacks(self, getkey):
         class RecordingCallback(klax.Callback):
             def __init__(self):
                 self.start_steps = []
@@ -113,7 +113,7 @@ class TestRunTrainingLoop:
 
         callback = RecordingCallback()
 
-        updated_view = klax.run_training_loop(view, [callback])
+        updated_view = klax.fit(view, [callback])
 
         assert callback.start_steps == [0]
         assert callback.steps == [1, 2, 3]
@@ -128,7 +128,7 @@ class TestRunTrainingLoop:
             )
         )
 
-    def test_run_training_loop_zero_steps_no_updates(self, getkey):
+    def test_fit_zero_steps_no_updates(self, getkey):
         class RecordingCallback(klax.Callback):
             def __init__(self):
                 self.start_steps = []
@@ -164,7 +164,7 @@ class TestRunTrainingLoop:
 
         callback = RecordingCallback()
 
-        updated_view = klax.run_training_loop(view, [callback])
+        updated_view = klax.fit(view, [callback])
 
         assert callback.start_steps == [0]
         assert callback.steps == []
@@ -179,7 +179,7 @@ class TestRunTrainingLoop:
             )
         )
 
-    def test_run_training_loop_stops_on_callback(self, getkey):
+    def test_fit_stops_on_callback(self, getkey):
         class StopAfterOne(klax.Callback):
             def __init__(self):
                 self.steps = []
@@ -212,7 +212,7 @@ class TestRunTrainingLoop:
 
         callback = StopAfterOne()
 
-        updated_view = klax.run_training_loop(view, [callback])
+        updated_view = klax.fit(view, [callback])
 
         assert callback.steps == [1]
         assert callback.end_steps == [1]
@@ -227,62 +227,28 @@ class TestRunTrainingLoop:
         )
 
 
-class TestFit:
-    def test_fit_returns_history_with_loss(self, getkey):
-        model = klax.nn.FICNN(2, "scalar", [4, 4], key=getkey())
+def test_simple_fit(getkey):
+    model = klax.nn.FICNN(2, "scalar", [4, 4], key=getkey())
 
-        data = (
-            jr.uniform(getkey(), (100, 2)),
-            jr.uniform(getkey(), (100,)),
-        )
+    data = (
+        jr.uniform(getkey(), (100, 2)),
+        jr.uniform(getkey(), (100,)),
+    )
 
-        trained_model, history = klax.fit(
-            model,
-            data,
-            batch_size=5,
-            batch_axes=0,
-            steps=5,
-            loss=klax.mse,
-            optimizer=optax.sgd(0.1),
-            key=getkey(),
-        )
+    trained_model, history = klax.simple_fit(
+        model,
+        data,
+        batch_size=5,
+        batch_axes=0,
+        steps=5,
+        loss=klax.mse,
+        optimizer=optax.sgd(0.1),
+        key=getkey(),
+    )
 
-        assert isinstance(trained_model, klax.nn.FICNN)
-        assert history.total_steps == 5
-        assert "loss" in history.content
-        loss_steps, loss_values = history["loss"]
-        assert loss_steps == [0]
-        assert len(loss_values) == 1
-
-    def test_fit_without_logger_returns_empty_history(self, getkey):
-        model = klax.nn.FICNN(2, "scalar", [4, 4], key=getkey())
-
-        data = (
-            jr.uniform(getkey(), (100, 2)),
-            jr.uniform(getkey(), (100,)),
-        )
-        trained_model, history = klax.fit(
-            model,
-            data,
-            batch_size=5,
-            batch_axes=0,
-            steps=5,
-            loss=klax.mse,
-            optimizer=optax.sgd(0.1),
-            logger=None,
-            key=getkey(),
-        )
-        initial_leaves = eqx.filter(model, eqx.is_inexact_array)
-
-        assert history.total_steps == -1
-        assert history.content == {}
-        updated_leaves = eqx.filter(trained_model, eqx.is_inexact_array)
-        assert not jax.tree.all(
-            jax.tree.map(
-                lambda a, b: jnp.array_equal(a, b)
-                if isinstance(a, jnp.ndarray)
-                else a == b,
-                initial_leaves,
-                updated_leaves,
-            )
-        )
+    assert isinstance(trained_model, klax.nn.FICNN)
+    assert history.total_steps == 5
+    assert "loss" in history.content
+    loss_steps, loss_values = history["loss"]
+    assert loss_steps == [0]
+    assert len(loss_values) == 1

--- a/tests/test_trainstate.py
+++ b/tests/test_trainstate.py
@@ -1,7 +1,10 @@
+from collections.abc import Generator
+
 import jax
 import jax.numpy as jnp
 import optax
 import pytest
+from jaxtyping import PyTreeDef
 
 from klax import make_view
 
@@ -41,14 +44,14 @@ class TestTrainingView:
         # Leaves and tree defs are set
         m_leaves, m_treedef = jax.tree.flatten(model)
         o_leaves, o_treedef = jax.tree.flatten(opt_state)
-        assert view.state.model_leaves == m_leaves
-        assert view.state.opt_state_leaves == o_leaves
-        assert view.static.model_tree_def == m_treedef
-        assert view.static.opt_state_tree_def == o_treedef
+        assert view._state.model_leaves == m_leaves
+        assert view._state.opt_state_leaves == o_leaves
+        assert view._static.model_tree_def == m_treedef
+        assert view._static.opt_state_tree_def == o_treedef
 
         # Optimizer is wrapped with extra args support
         assert isinstance(
-            view.static.optimizer, optax.GradientTransformationExtraArgs
+            view._static.optimizer, optax.GradientTransformationExtraArgs
         )
 
         # If already wrapped, keep identity
@@ -62,7 +65,7 @@ class TestTrainingView:
             loss=object(),
             steps=3,
         )
-        assert view2.static.optimizer is wrapped
+        assert view2._static.optimizer is wrapped
 
     def test_assemble_disassemble_model_and_opt_state(self):
         model = {"w": jnp.array([1.0, 2.0]), "b": jnp.array(0.0)}
@@ -73,17 +76,19 @@ class TestTrainingView:
             model, optimizer, opt_state, dummy_batch(), 0, object(), 2
         )
 
-        model_round = view.static.assemble_model(view.state.model_leaves)
+        model_round = view._static.assemble_model(view._state.model_leaves)
         tree_allclose(model_round, model)
 
-        leaves = view.static.disassemble_model(model_round)
-        assert leaves == view.state.model_leaves
+        leaves = view._static.disassemble_model(model_round)
+        assert leaves == view._state.model_leaves
 
-        opt_round = view.static.assemble_opt_state(view.state.opt_state_leaves)
+        opt_round = view._static.assemble_opt_state(
+            view._state.opt_state_leaves
+        )
         tree_allclose(opt_round, opt_state)
 
-        o_leaves = view.static.disassemble_opt_state(opt_round)
-        assert o_leaves == view.state.opt_state_leaves
+        o_leaves = view._static.disassemble_opt_state(opt_round)
+        assert o_leaves == view._state.opt_state_leaves
 
     def test_disassemble_model_mismatch_raises(self):
         model = {"w": jnp.array([1.0, 2.0]), "b": jnp.array(0.0)}
@@ -96,7 +101,7 @@ class TestTrainingView:
         )
 
         with pytest.raises(ValueError, match="Model structure changed"):
-            view.static.disassemble_model(other)
+            view._static.disassemble_model(other)
 
     def test_disassemble_opt_state_mismatch_raises(self):
         model = {"w": jnp.array([1.0, 2.0]), "b": jnp.array(0.0)}
@@ -109,7 +114,7 @@ class TestTrainingView:
         )
 
         with pytest.raises(ValueError, match="Opt state structure changed"):
-            view.static.disassemble_opt_state(other_opt)
+            view._static.disassemble_opt_state(other_opt)
 
     def test_trainingview_model_property_caching_and_setter(self):
         model = {"w": jnp.array([1.0, 2.0]), "b": jnp.array(0.0)}
@@ -128,7 +133,7 @@ class TestTrainingView:
         new_model = {"w": model["w"] + 1, "b": model["b"] + 1}
         view.model = new_model
         tree_allclose(view.model, new_model)
-        roundtrip = view.static.assemble_model(view.state.model_leaves)
+        roundtrip = view._static.assemble_model(view._state.model_leaves)
         tree_allclose(roundtrip, new_model)
 
     def test_trainingview_opt_state_getter_setter(self):
@@ -148,5 +153,54 @@ class TestTrainingView:
         new_opt = {"m": {"w": jnp.ones(2), "b": jnp.ones(())}}
         view.opt_state = new_opt
         tree_allclose(view.opt_state, new_opt)
-        roundtrip = view.static.assemble_opt_state(view.state.opt_state_leaves)
+        roundtrip = view._static.assemble_opt_state(
+            view._state.opt_state_leaves
+        )
         tree_allclose(roundtrip, new_opt)
+
+    def test_static_properties(self):
+        model = {"w": jnp.array([1.0, 2.0]), "b": jnp.array(0.0)}
+        opt_state = {"m": {"w": jnp.zeros(2), "b": jnp.zeros(())}}
+        optimizer = optax.adam(1e-3)
+        loss = object()
+        batch_axes = 0
+        steps = 2
+        view = make_view(
+            model,
+            optimizer,
+            opt_state,
+            dummy_batch(),
+            batch_axes=batch_axes,
+            loss=loss,
+            steps=steps,
+        )
+
+        assert view.model_tree_def == jax.tree.structure(model)
+        with pytest.raises(AttributeError):
+            view.model_tree_def = "something"
+
+        assert isinstance(
+            view.optimizer, optax.GradientTransformationExtraArgs
+        )
+        with pytest.raises(AttributeError):
+            view.optimizer = "something"
+
+        assert isinstance(view.opt_state_tree_def, PyTreeDef)
+        with pytest.raises(AttributeError):
+            view.opt_state_tree_def = "something"
+
+        assert isinstance(view.batch, Generator)
+        with pytest.raises(AttributeError):
+            view.batch = "something"
+
+        assert view.batch_axes == batch_axes
+        with pytest.raises(AttributeError):
+            view.batch_axes = "something"
+
+        assert view.loss is loss
+        with pytest.raises(AttributeError):
+            view.loss = "something"
+
+        assert view.steps == steps
+        with pytest.raises(AttributeError):
+            view.steps = "something"

--- a/tests/test_trainstate.py
+++ b/tests/test_trainstate.py
@@ -3,7 +3,7 @@ import jax.numpy as jnp
 import optax
 import pytest
 
-from klax._trainstate import TrainingView, make_state_and_static
+from klax import make_view
 
 
 def tree_allclose(a, b):
@@ -22,13 +22,13 @@ def dummy_batch():
         yield {"x": jnp.array([0.0])}
 
 
-class TestTrainstate:
-    def test_make_state_and_static_wraps_optimizer_and_sets_defs(self):
+class TestTrainingView:
+    def test_make_view_wraps_optimizer_and_sets_defs(self):
         model = {"w": jnp.array([1.0, 2.0]), "b": jnp.array(0.0)}
         opt_state = {"m": {"w": jnp.zeros(2), "b": jnp.zeros(())}}
         optimizer = optax.adam(1e-3)
 
-        state, static = make_state_and_static(
+        view = make_view(
             model=model,
             optimizer=optimizer,
             opt_state=opt_state,
@@ -41,19 +41,19 @@ class TestTrainstate:
         # Leaves and tree defs are set
         m_leaves, m_treedef = jax.tree.flatten(model)
         o_leaves, o_treedef = jax.tree.flatten(opt_state)
-        assert state.model_leaves == m_leaves
-        assert state.opt_state_leaves == o_leaves
-        assert static.model_tree_def == m_treedef
-        assert static.opt_state_tree_def == o_treedef
+        assert view.state.model_leaves == m_leaves
+        assert view.state.opt_state_leaves == o_leaves
+        assert view.static.model_tree_def == m_treedef
+        assert view.static.opt_state_tree_def == o_treedef
 
         # Optimizer is wrapped with extra args support
         assert isinstance(
-            static.optimizer, optax.GradientTransformationExtraArgs
+            view.static.optimizer, optax.GradientTransformationExtraArgs
         )
 
         # If already wrapped, keep identity
         wrapped = optax.with_extra_args_support(optax.sgd(1.0))
-        _, static2 = make_state_and_static(
+        view2 = make_view(
             model=model,
             optimizer=wrapped,
             opt_state=opt_state,
@@ -62,28 +62,28 @@ class TestTrainstate:
             loss=object(),
             steps=3,
         )
-        assert static2.optimizer is wrapped
+        assert view2.static.optimizer is wrapped
 
     def test_assemble_disassemble_model_and_opt_state(self):
         model = {"w": jnp.array([1.0, 2.0]), "b": jnp.array(0.0)}
         opt_state = {"m": {"w": jnp.zeros(2), "b": jnp.zeros(())}}
         optimizer = optax.adam(1e-3)
 
-        state, static = make_state_and_static(
+        view = make_view(
             model, optimizer, opt_state, dummy_batch(), 0, object(), 2
         )
 
-        model_round = static.assemble_model(state.model_leaves)
+        model_round = view.static.assemble_model(view.state.model_leaves)
         tree_allclose(model_round, model)
 
-        leaves = static.disassemble_model(model_round)
-        assert leaves == state.model_leaves
+        leaves = view.static.disassemble_model(model_round)
+        assert leaves == view.state.model_leaves
 
-        opt_round = static.assemble_opt_state(state.opt_state_leaves)
+        opt_round = view.static.assemble_opt_state(view.state.opt_state_leaves)
         tree_allclose(opt_round, opt_state)
 
-        o_leaves = static.disassemble_opt_state(opt_round)
-        assert o_leaves == state.opt_state_leaves
+        o_leaves = view.static.disassemble_opt_state(opt_round)
+        assert o_leaves == view.state.opt_state_leaves
 
     def test_disassemble_model_mismatch_raises(self):
         model = {"w": jnp.array([1.0, 2.0]), "b": jnp.array(0.0)}
@@ -91,12 +91,12 @@ class TestTrainstate:
         opt_state = {"m": {"w": jnp.zeros(2), "b": jnp.zeros(())}}
         optimizer = optax.adam(1e-3)
 
-        _, static = make_state_and_static(
+        view = make_view(
             model, optimizer, opt_state, dummy_batch(), 0, object(), 2
         )
 
         with pytest.raises(ValueError, match="Model structure changed"):
-            static.disassemble_model(other)
+            view.static.disassemble_model(other)
 
     def test_disassemble_opt_state_mismatch_raises(self):
         model = {"w": jnp.array([1.0, 2.0]), "b": jnp.array(0.0)}
@@ -104,23 +104,22 @@ class TestTrainstate:
         other_opt = {"m": {"w": jnp.zeros(2), "c": jnp.zeros(())}}
         optimizer = optax.adam(1e-3)
 
-        _, static = make_state_and_static(
+        view = make_view(
             model, optimizer, opt_state, dummy_batch(), 0, object(), 2
         )
 
         with pytest.raises(ValueError, match="Opt state structure changed"):
-            static.disassemble_opt_state(other_opt)
+            view.static.disassemble_opt_state(other_opt)
 
     def test_trainingview_model_property_caching_and_setter(self):
         model = {"w": jnp.array([1.0, 2.0]), "b": jnp.array(0.0)}
         opt_state = {"m": {"w": jnp.zeros(2), "b": jnp.zeros(())}}
         optimizer = optax.adam(1e-3)
 
-        state, static = make_state_and_static(
+        view = make_view(
             model, optimizer, opt_state, dummy_batch(), 0, object(), 2
         )
 
-        view = TrainingView(state, static)
         # Getter assembles and caches
         m1 = view.model
         tree_allclose(m1, model)
@@ -129,7 +128,7 @@ class TestTrainstate:
         new_model = {"w": model["w"] + 1, "b": model["b"] + 1}
         view.model = new_model
         tree_allclose(view.model, new_model)
-        roundtrip = static.assemble_model(state.model_leaves)
+        roundtrip = view.static.assemble_model(view.state.model_leaves)
         tree_allclose(roundtrip, new_model)
 
     def test_trainingview_opt_state_getter_setter(self):
@@ -137,11 +136,10 @@ class TestTrainstate:
         opt_state = {"m": {"w": jnp.zeros(2), "b": jnp.zeros(())}}
         optimizer = optax.adam(1e-3)
 
-        state, static = make_state_and_static(
+        view = make_view(
             model, optimizer, opt_state, dummy_batch(), 0, object(), 2
         )
 
-        view = TrainingView(state, static)
         # Getter assembles and returns opt state
         os1 = view.opt_state
         tree_allclose(os1, opt_state)
@@ -150,5 +148,5 @@ class TestTrainstate:
         new_opt = {"m": {"w": jnp.ones(2), "b": jnp.ones(())}}
         view.opt_state = new_opt
         tree_allclose(view.opt_state, new_opt)
-        roundtrip = static.assemble_opt_state(state.opt_state_leaves)
+        roundtrip = view.static.assemble_opt_state(view.state.opt_state_leaves)
         tree_allclose(roundtrip, new_opt)


### PR DESCRIPTION
Improved clarity and user-friendliness for `fit`.
Key changes:
- `fit` no longer exposes the `MetricLogger` as argument. Instead, the `MetricLoggers` init-args are exposed.
- Metrics now keep track of their names and verbosity temselfs. This simplifies specifying new metrics for `fit`.
- The `TrainingView` now exposes all components of `static` via properties, making it more intuitive to write custom callbacks.