### PR TITLE
Klax 0.3.1

### DIFF
--- a/klax/_initializers.py
+++ b/klax/_initializers.py
@@ -89,7 +89,7 @@ def hoedt_normal(
     signal propagation through layers with non-negative weights.
 
     Tip:
-        This initiailzation should be paired with the [`klax.hoedt_bias`][]
+        This initialization should be paired with the [`klax.hoedt_bias`][]
         initializer for biases of constrained layers.
 
     Args:
@@ -128,7 +128,7 @@ def hoedt_bias() -> Initializer:
 
     A [Hoedt bias initializer](https://arxiv.org/abs/2312.12474) is designed
     for the _unconstrained_ biases in linear layers where the weights are constrained
-    to be positive, such as in [`klax.nn.FICNN`][]. It intializes biases to vectors of
+    to be positive, such as in [`klax.nn.FICNN`][]. It initializes biases to vectors of
     a constant value, computed from the number of input features (`fan_in`).
 
     Tip:

--- a/klax/_serialization.py
+++ b/klax/_serialization.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Serialization deseriablizastion specs for `equinox.Module`."""
+"""Serialization deserialization specs for `equinox.Module`."""
 
 from typing import Any, BinaryIO
 

--- a/klax/_training.py
+++ b/klax/_training.py
@@ -202,8 +202,7 @@ def fit[T: eqx.Module](
             - 2: A progressbar is used and updated every `log_every` steps.
             Defaults to `2`.
         callbacks: List of [Callbacks][klax.Callback]. They can be used to
-            implement early stopping, custom logging and more. The argument
-            to the callback function is aCallbackArgs object.
+            implement early stopping, custom logging and more.
             Defaults to `None`.
         key: A `jax.random.PRNGKey` used to provide randomness for batch
             generation.

--- a/klax/_training.py
+++ b/klax/_training.py
@@ -171,19 +171,18 @@ def fit[T: eqx.Module](
             Defaults to `None`
         steps: Number of gradient updates to apply.
             Defaults to 1000.
-        loss: The loss function with call signature
-            `(model: PyTree, data: PyTree, run_state: PyTree) -> float`.
-            Defaults to `mse`.
+        loss: [`Loss`][klax.Loss] object defining the loss function.
+            Defaults to [`mse`][klax.mse].
         optimizer: The optimizer. Any optax gradient transform to calculate
             the updates for the model.
             Defaults to optax.adam(1e-3).
         init_opt_state: The initial state of the optimizer. If `None`, the
             optimizer is initialized from scratch. By providing a value for
             `init_opt_state`, the user can resume training from a previous
-            state (e.g., obtained from the `HistoryCallback.last_opt_state`).
+            state (e.g., obtained from `history.final_opt_state`).
             Defaults to `None`.
         batcher: The data loader that splits inputs and targets into batches.
-            Defaults to `batch_data`.
+            Defaults to [`batch_data`][klax.batch_data].
         make_logger: Wether to create a [`MetricLogger`][klax.MetricLogger].
             If `False` the arguments `metrics`, `log_every` and `verbose`
             don't have any effect and `fit` will return `None` instead of a

--- a/klax/_wrappers.py
+++ b/klax/_wrappers.py
@@ -216,7 +216,7 @@ class NonTrainable(Unwrappable[T]):
     """Applies stop gradient to all ArrayLike leaves before unwrapping.
 
     See also [`klax.non_trainable`][], which is probably a generally preferable
-    way to achieve similar behaviour, which wraps the ArrayLike leaves
+    way to achieve similar behavior, which wraps the ArrayLike leaves
     directly, rather than the tree. Useful to mark PyTrees (Arrays, Modules,
     etc.) as frozen/non-trainable. Note that the underlying parameters may
     still be impacted by regularization, so it is generally advised to use this
@@ -457,7 +457,7 @@ def finalize(tree: PyTree):
 
         ```python
         >>> finalized_model = klax.finalize(model)
-        >>> y = finalzed_model(x)            # Call finalized model
+        >>> y = finalized_model(x)           # Call finalized model
         >>> model, history = fit(model, ...) # Continue training with constrained model
         ```
 

--- a/klax/nn/_icnn.py
+++ b/klax/nn/_icnn.py
@@ -729,7 +729,7 @@ class PICNN(eqx.Module, strict=True):
 
                 Note: If `use_passthrough=True` and `non_decreasing=True` then
                 `activation_xu` has to be a non-negative function to guarantee
-                convexity with respect to `x`. We recomment avoiding passthrough
+                convexity with respect to `x`. We recommend avoiding passthrough
                 for non-decreasing PICNNs.
                 Defaults to False.
             weight_init: The weight initializer of type `SupportedInitializer`

--- a/klax/nn/_linear.py
+++ b/klax/nn/_linear.py
@@ -85,7 +85,7 @@ class Linear(eqx.Module, strict=True):
                 Defaults to either `jax.numpy.float32` or `jax.numpy.float64`
                 depending on whether JAX is in 64-bit mode.
             key: A `jax.random.PRNGKey` used to provide randomness for
-                parameter initialisation. (Keyword only argument.)
+                parameter initialization. (Keyword only argument.)
 
         Note:
             Note that `in_features` also supports the string `"scalar"` as a

--- a/klax/nn/_matrices.py
+++ b/klax/nn/_matrices.py
@@ -89,7 +89,7 @@ class Matrix(eqx.Module):
                 (Defaults to either `jax.numpy.float32` or `jax.numpy.float64`
                 depending on whether JAX is in 64-bit mode.)
             key: A `jax.random.PRNGKey` used to provide randomness for
-                parameter initialisation. (Keyword only argument.)
+                parameter initialization. (Keyword only argument.)
 
         Note:
             Note that `in_size` also supports the string `"scalar"` as a
@@ -153,7 +153,7 @@ class ConstantMatrix(eqx.Module):
 
         Args:
             shape: The matrix shape. The output from the module will be a Array
-                with sthe specified `shape`. For square matrices a single
+                with the specified `shape`. For square matrices a single
                 integer N can be used as a shorthand for (N, N).
             init: The array initializer of type
                 `Initializer`. (Defaults to
@@ -162,7 +162,7 @@ class ConstantMatrix(eqx.Module):
                 (Defaults to either `jax.numpy.float32` or `jax.numpy.float64`
                 depending on whether JAX is in 64-bit mode.)
             key: A `jax.random.PRNGKey` used to provide randomness for
-                parameter initialisation. (Keyword only argument.)
+                parameter initialization. (Keyword only argument.)
 
         """
         dtype = default_floating_dtype() if dtype is None else dtype
@@ -185,7 +185,7 @@ class ConstantMatrix(eqx.Module):
 
 
 class SkewSymmetricMatrix(eqx.Module):
-    """A kkew-symmetric matrix-valued function based on an MLP.
+    """A skew-symmetric matrix-valued function based on an MLP.
 
     The MLP maps the input to a vector of elements that are transformed into a
     skew-symmetric matrix.
@@ -215,7 +215,7 @@ class SkewSymmetricMatrix(eqx.Module):
             in_size: The input size. The input to the module should be a vector
                 of shape `(in_size,)`
             shape: The matrix shape. The output from the module will be a Array
-                with sthe specified `shape`. For square matrices a single
+                with the specified `shape`. For square matrices a single
                 integer N can be used as a shorthand for (N, N).
             width_sizes: The sizes of each hidden layer of the underlying MLP
                 in a list.
@@ -235,7 +235,7 @@ class SkewSymmetricMatrix(eqx.Module):
                 (Defaults to either `jax.numpy.float32` or `jax.numpy.float64`
                 depending on whether JAX is in 64-bit mode.)
             key: A `jax.random.PRNGKey` used to provide randomness for
-                parameter initialisation. (Keyword only argument.)
+                parameter initialization. (Keyword only argument.)
 
         Note:
             Note that `in_size` also supports the string `"scalar"` as a
@@ -284,7 +284,7 @@ class SkewSymmetricMatrix(eqx.Module):
 class ConstantSkewSymmetricMatrix(eqx.Module):
     """A constant skew-symmetric matrix.
 
-    It is a wrapper around a constant skew-symmetry-constraind array that
+    It is a wrapper around a constant skew-symmetry-constrained array that
     implements the matrix-valued function interface.
     """
 
@@ -305,7 +305,7 @@ class ConstantSkewSymmetricMatrix(eqx.Module):
 
         Args:
             shape: The matrix shape. The output from the module will be a Array
-                with sthe specified `shape`. For square matrices a single
+                with the specified `shape`. For square matrices a single
                 integer N can be used as a shorthand for (N, N).
             init: The array initializer of type
                 `Initializer`. (Defaults to
@@ -314,7 +314,7 @@ class ConstantSkewSymmetricMatrix(eqx.Module):
                 (Defaults to either `jax.numpy.float32` or `jax.numpy.float64`
                 depending on whether JAX is in 64-bit mode.)
             key: A `jax.random.PRNGKey` used to provide randomness for
-                parameter initialisation. (Keyword only argument.)
+                parameter initialization. (Keyword only argument.)
 
         """
         dtype = default_floating_dtype() if dtype is None else dtype
@@ -375,7 +375,7 @@ class SPDMatrix(eqx.Module):
             in_size: The input size. The input to the module should be a vector
                 of shape `(in_size,)`
             shape: The matrix shape. The output from the module will be a Array
-                with sthe specified `shape`. For square matrices a single
+                with the specified `shape`. For square matrices a single
                 integer N can be used as a shorthand for (N, N).
             width_sizes: The sizes of each hidden layer of the underlying MLP
                 in a list.
@@ -399,7 +399,7 @@ class SPDMatrix(eqx.Module):
                 (Defaults to either `jax.numpy.float32` or `jax.numpy.float64`
                 depending on whether JAX is in 64-bit mode.)
             key: A `jax.random.PRNGKey` used to provide randomness for
-                parameter initialisation. (Keyword only argument.)
+                parameter initialization. (Keyword only argument.)
 
         Note:
             Note that `in_size` also supports the string `"scalar"` as a
@@ -451,7 +451,7 @@ class SPDMatrix(eqx.Module):
 class ConstantSPDMatrix(eqx.Module):
     """A constant symmetric positive definite matrix-valued function.
 
-    It is a wrapper around a constant symmetric postive semi-definite matrix
+    It is a wrapper around a constant symmetric positive semi-definite matrix
     with the matrix-valued function interface.
     """
 
@@ -474,7 +474,7 @@ class ConstantSPDMatrix(eqx.Module):
 
         Args:
             shape: The matrix shape. The output from the module will be a
-                Array with sthe specified `shape`. For square matrices a single
+                Array with the specified `shape`. For square matrices a single
                 integer N can be used as a shorthand for (N, N).
             epsilon: Small value that is added to the diagonal of the output
                 matrix to ensure positive definiteness. If only positive
@@ -488,7 +488,7 @@ class ConstantSPDMatrix(eqx.Module):
                 (Defaults to either `jax.numpy.float32` or `jax.numpy.float64`
                 depending on whether JAX is in 64-bit mode.)
             key: A `jax.random.PRNGKey` used to provide randomness for
-                parameter initialisation. (Keyword only argument.)
+                parameter initialization. (Keyword only argument.)
 
         """
         shape = shape if isinstance(shape, tuple) else (shape, shape)

--- a/klax/nn/_mlp.py
+++ b/klax/nn/_mlp.py
@@ -88,7 +88,7 @@ class MLP(eqx.Module, strict=True):
                 Defaults to either `jax.numpy.float32` or `jax.numpy.float64`
                 depending on whether JAX is in 64-bit mode.
             key: A `jax.random.PRNGKey` used to provide randomness for
-                parameter initialisation. (Keyword only argument.)
+                parameter initialization. (Keyword only argument.)
 
         Note:
             Note that `in_size` also supports the string `"scalar"` as a


### PR DESCRIPTION
- [x] Fixed docs and docsting error in `klax.fit`.
- [ ] Version bump
- [ ] Address minor issues, like `klax.finalize` types, see #70
- [ ] Rename `steps` to `max_steps` in the `TrainingContext` (and `ScipyTrainingContext`)