### PR TITLE
Add xarray support

### DIFF
--- a/commit.msg
+++ b/commit.msg
@@ -1,0 +1,34 @@
+Add xarray support to batch_data and split_data
+
+`klax.batch_data` and `klax.split_data` previously crashed on `xr.Dataset`
+and `xr.DataArray` inputs because the broadcast in `broadcast_and_get_size`
+tried to rebuild an xarray container with integer leaves, violating
+xarray's dim/coord invariants.
+
+Refactor the data handlers to treat xarray containers as opaque leaves and
+dispatch slicing by leaf type. `batch_axes` leaves now accept `int | str |
+None`: `int` is a positional axis on an array leaf, `str` is a dim name on
+an xarray leaf, `None` skips a subtree. A `str` spec on a non-xarray leaf
+and an `int` spec on an xarray leaf both raise a `TypeError` with the
+available alternatives spelled out.
+
+xarray is an optional dependency. `klax._datahandler` imports it behind a
+`_HAS_XARRAY` flag; if it is missing, the new code paths are dead and
+plain-pytree batching behaves exactly as before. A new
+`xarray-experimental` extra wires up `xarray` and `gdm-xarray-jax` for
+users who want named-dim batching (and `xarray_jax`-backed pytree
+registration when JIT'ing a loss that takes xarray batches).
+
+- klax/_datahandler.py: add `_is_xarray`, `_is_leaf`, `_normalize_one`,
+  `_broadcast_spec`, `_leaf_size`, `_leaf_take`; rewrite
+  `broadcast_and_get_size`, `batch_data`, `split_data` around them; widen
+  the `Batcher` Protocol; update docstrings with xarray examples.
+- klax/_training.py, klax/_logging.py: widen `batch_axes` type annotation
+  to `PyTree[int | str | None]` and update the `fit` docstring.
+- pyproject.toml: add `xarray-experimental` extra (xarray + gdm-xarray-jax
+  pinned via uv source to the upstream tag).
+- tests/test_datahandler.py: add `TestBatchDataXArray` and
+  `TestSplitDataXArray` (Dataset, DataArray, mixed pytrees, None
+  passthrough, error cases) gated on `pytest.importorskip("xarray")`.
+- tests/test_training.py: add `test_default_behavior_with_xarray` end-to-end
+  with `xarray_jax` registration.

--- a/klax/_datahandler.py
+++ b/klax/_datahandler.py
@@ -26,57 +26,162 @@ import jax.random as jr
 import numpy as np
 from jaxtyping import PRNGKeyArray, PyTree
 
+try:
+    import xarray as xr
+
+    _HAS_XARRAY = True
+except ImportError:
+    xr = None  # type: ignore[assignment]
+    _HAS_XARRAY = False
+
+
+def _is_xarray(x: Any) -> bool:
+    """Return True if `x` is an xarray container that klax handles natively."""
+    return _HAS_XARRAY and isinstance(
+        x, (xr.Dataset, xr.DataArray, xr.Variable)
+    )
+
+
+def _is_leaf(x: Any) -> bool:
+    """Tree-traversal stop predicate used throughout this module.
+
+    Stops at `None` (the "do not batch this subtree" sentinel) and at xarray
+    containers (treated as opaque leaves so we can use named-dim slicing
+    instead of fighting xarray's invariants during tree reconstruction).
+    """
+    return x is None or _is_xarray(x)
+
+
+def _resolve_one(spec: Any, leaf: Any) -> int | str | None:
+    """Resolve one `(spec, leaf)` pair to its normalized form.
+
+    The normalized value is a single token that downstream code can carry in a
+    pytree of the same shape as `data`:
+
+    - `None`  — do not batch this leaf
+    - `int`   — positional axis on an array leaf
+    - `str`   — dim name on an xarray leaf
+    """
+    if spec is None:
+        return None
+    if _is_xarray(leaf):
+        if not isinstance(spec, str):
+            raise TypeError(
+                f"batch_axes spec for an xarray leaf must be a `str` dim name, "
+                f"got {type(spec).__name__} ({spec!r}). "
+                f"Available dims: {tuple(leaf.sizes)}"
+            )
+        if spec not in leaf.sizes:
+            raise ValueError(
+                f"Dim '{spec}' not present on xarray leaf. "
+                f"Available dims: {tuple(leaf.sizes)}"
+            )
+        return spec
+    # Non-xarray, non-None leaf.
+    if isinstance(spec, str):
+        raise TypeError(
+            f"String dim names are only valid for xarray leaves; "
+            f"got '{spec}' on a leaf of type {type(leaf).__name__}"
+        )
+    if not eqx.is_array(leaf):
+        # Mirror the legacy `eqx.if_array` behavior: a non-array leaf paired
+        # with an int spec is silently treated as "do not batch". This keeps
+        # `batch_axes=0` ergonomic when users mix array data with scalars,
+        # strings, or other non-array metadata in the same pytree.
+        return None
+    return int(spec)
+
+
+def _broadcast_spec(spec: Any, subtree: Any) -> Any:
+    """Broadcast a single spec across a (possibly nested) data subtree."""
+    return jax.tree.map(
+        lambda leaf: _resolve_one(spec, leaf),
+        subtree,
+        is_leaf=_is_leaf,
+    )
+
+
+def _leaf_size(leaf: Any, spec: int | str | None) -> int | None:
+    if spec is None:
+        return None
+    if isinstance(spec, str):
+        return int(leaf.sizes[spec])
+    return int(leaf.shape[spec])
+
+
+def _leaf_take(leaf: Any, spec: int | str | None, indices: Any) -> Any:
+    if spec is None:
+        return leaf
+    if isinstance(spec, str):
+        return leaf.isel({spec: indices})
+    if spec == 0:
+        return leaf[indices]
+    if isinstance(leaf, np.ndarray):
+        return np.take(leaf, np.asarray(indices), axis=spec)
+    return jnp.take(leaf, indices, axis=spec)
+
 
 def broadcast_and_get_size[T](
     data: PyTree[Any, "T"],
-    batch_axes: PyTree[int | None, "T ..."],  # type: ignore
-) -> tuple[PyTree[int | None, "T"], int]:
+    batch_axes: PyTree[int | str | None, "T ..."],
+) -> tuple[PyTree[int | str | None, "T"], int]:
     """Broadcast `batch_axes` to the same structure as `data` and get size.
 
     Args:
-        data: PyTree of data.
-        batch_axes: PyTree of the batch axis indices. `None` is used to
-            indicate that the corresponding leaf or subtree in data does not
-            have a batch axis. `batch_axes` must have the same structure as
-            `data` or have `data` as a prefix.
+        data: PyTree of data. Leaves may be JAX/NumPy arrays, xarray
+            `Dataset`/`DataArray`/`Variable` objects, or non-array Python
+            values (which are passed through unchanged).
+        batch_axes: PyTree of batch-axis specifications. Each leaf is one of:
+
+            - `int`: positional axis on an array leaf.
+            - `str`: dim name on an xarray leaf (requires xarray dependency).
+            - `None`: the corresponding leaf or subtree in `data` is not
+              batched.
+
+            `batch_axes` must have the same structure as `data` or have
+            `data` as a prefix. When `batch_axes` is a prefix, the spec at
+            each prefix leaf is broadcast over the corresponding subtree of
+            `data`: array leaves get the spec, non-array non-xarray leaves
+            (scalars, strings, ...) are silently treated as non-batched.
 
     Raises:
-        ValueError: If `batch_axes` is not a prefix of `data`.
-        ValueError: If not all batch axes have the same size.
+        TypeError: If a `str` spec is given for a non-xarray leaf or an
+            `int` spec is given for an xarray leaf.
+        ValueError: If a `str` dim name is not present on the corresponding
+            xarray leaf, or if not all batched arrays have equal batch sizes.
 
     Returns:
-        Tuple of the broadcasted `batch_axes` and the `dataset_size`.
+        Tuple of the resolved `batch_axes` (same structure as `data`,
+        leaves are `int | str | None`) and the `dataset_size`.
 
     """
-    try:
-        batch_axes = jax.tree.map(
-            lambda a, d: jax.tree.map(eqx.if_array(a), d),
-            batch_axes,
-            data,
-            is_leaf=lambda x: x is None,
-        )
-    except ValueError as e:
-        raise ValueError("batch_axes must be a prefix of data.")
-
-    batch_sizes = jax.tree.map(
-        lambda a, d: None if a is None else d.shape[a],
+    resolved_axes = jax.tree.map(
+        _broadcast_spec,
         batch_axes,
         data,
-        is_leaf=lambda x: x is None,
+        is_leaf=_is_leaf,
     )
-    leaves = jax.tree.leaves(batch_sizes)
-    if len(leaves) == 0:
+
+    sizes = jax.tree.map(
+        _leaf_size,
+        data,
+        resolved_axes,
+        is_leaf=_is_leaf,
+    )
+    leaves = [
+        s for s in jax.tree.leaves(sizes, is_leaf=_is_leaf) if s is not None
+    ]
+    if not leaves:
         # No leaf in data has a batch dimension -> singelton data set
         dataset_size = 1
     else:
         if not all(v == leaves[0] for v in leaves):
             raise ValueError(
-                "All batched arrays must have equal batch sizes. "
-                f"{batch_sizes=}"
+                f"All batched arrays must have equal batch sizes. {sizes=}"
             )
         dataset_size = leaves[0]
 
-    return batch_axes, dataset_size
+    return resolved_axes, dataset_size
 
 
 @typing.runtime_checkable
@@ -85,7 +190,7 @@ class Batcher(Protocol):
         self,
         data: PyTree[Any],
         batch_size: int,
-        batch_axes: PyTree[int | None],
+        batch_axes: PyTree[int | str | None],
         *,
         key: PRNGKeyArray,
     ) -> Generator[PyTree[Any], None, None]:
@@ -95,24 +200,25 @@ class Batcher(Protocol):
 def batch_data[T](
     data: PyTree[Any, "T"],
     batch_size: int,
-    batch_axes: PyTree[int | None] = 0,
+    batch_axes: PyTree[int | str | None] = 0,
     convert_to_numpy: bool = True,
     *,
     key: PRNGKeyArray,
 ) -> Generator[PyTree[Any, "T"], None, None]:
     """Create a `Generator` that draws subsets of data without replacement.
 
-    The data can be any `PyTree` with `ArrayLike` leaves. If `batch_axes` is
-    passed, batch axes (including `None` for no batching) can be specified for
-    every leaf individually.
-    A generator is returned that indefinitely yields batches of data with size
-    `batch_size`. Examples are drawn without replacement until the remaining
-    dataset is smaller than `batch_size`, at which point the dataset will be
-    reshuffled and the process starts over.
+    The data can be any `PyTree` whose leaves are arrays, xarray
+    `Dataset`/`DataArray`/`Variable` objects, or non-array Python values.
+    `batch_axes` is a `PyTree` whose leaves are either positional axis
+    indices (`int`) for array leaves, dim names (`str`) for xarray leaves,
+    or `None` for leaves that should not be batched. A generator is returned
+    that indefinitely yields batches of data with size `batch_size`.
+    Examples are drawn without replacement until the remaining dataset is
+    smaller than `batch_size`, at which point the dataset is reshuffled and
+    the process starts over.
 
     Example:
-        This is an example for a nested `PyTree`, where the elements x and y
-        have batch dimension along the first axis.
+        Plain-array pytree:
 
         ```python
         >>> import klax
@@ -131,19 +237,35 @@ def batch_data[T](
         ... )
         ```
 
+        xarray dataset (requires the `xarray` extra, e.g.
+        `pip install klax[xarray]`):
+
+        ```python
+        >>> import xarray as xr  # doctest: +SKIP
+        >>> data = xr.Dataset(  # doctest: +SKIP
+        ...     {"y": (("batch", "i"), jnp.ones((100, 4)))},
+        ...     coords={"batch": jnp.arange(100), "i": jnp.arange(4)},
+        ... )
+        >>> batch = klax.batch_data(  # doctest: +SKIP
+        ...     data, 10, batch_axes="batch", key=jax.random.key(0)
+        ... )
+        ```
+
     Args:
-        data: The data that shall be batched. It can be any `PyTree` with
-            `ArrayLike` leaves.
+        data: The data that shall be batched.
         batch_size: The number of examples in a batch.
-        batch_axes: PyTree of the batch axis indices. `None` is used to
-            indicate that the corresponding leaf or subtree in data does not
-            have a batch axis. `batch_axes` must have the same structure as
-            `data` or have `data` as a prefix.
-            (Defaults to 0, meaning all leaves in `data` are
-            batched along their first dimension.)
-        convert_to_numpy: If `True`, batched data leafs will be converted to
-            Numpy arrays before batching. This is useful for performance
-            reasons, as Numpy's slicing is much faster than JAX's.
+        batch_axes: PyTree of batch-axis specifications. Each leaf is one of
+            `int` (positional axis on an array leaf), `str` (dim name on an
+            xarray leaf), or `None` (do not batch this subtree). `batch_axes`
+            must have the same structure as `data` or have `data` as a
+            prefix. (Defaults to `0`, meaning all array leaves in `data` are
+            batched along their first dimension. Note that with the default,
+            xarray leaves will raise a `TypeError`; you must pass an explicit
+            dim name for them.)
+        convert_to_numpy: If `True`, batched array leaves are converted to
+            NumPy arrays before batching. Numpy's slicing is much faster
+            than JAX's when running on CPU. xarray leaves are not touched
+            by this flag.
         key: A `jax.random.PRNGKey` used to provide randomness for batch
             generation. (Keyword only argument.)
 
@@ -151,25 +273,30 @@ def batch_data[T](
         A `Generator` that yields a random batch of data.
 
     Yields:
-        A `PyTree[ArrayLike]` with the same structure as `data`. Where all
-            batched leaves have `batch_size`.
+        A `PyTree` with the same structure as `data`, where each batched
+        leaf has been sliced to `batch_size` along its batch dimension.
 
     Note:
-        Note that if the size of the dataset is smaller than `batch_size`, the
-        used `batch_size` will be reduced.
+        Note that if the size of the dataset is smaller than `batch_size`,
+        the used `batch_size` will be reduced.
 
     """
-    batch_axes, dataset_size = broadcast_and_get_size(data, batch_axes)
+    resolved_axes, dataset_size = broadcast_and_get_size(data, batch_axes)
 
     # Convert to Numpy arrays. Numpy's slicing is much faster than JAX's, so
     # for fast model training steps this actually makes a huge difference!
     # However, be aware that this is likely only true if JAX runs on CPU.
+    # xarray containers are passed through unchanged — their internal data
+    # is already numpy-backed (or user-provided) and `.isel(...)` is used
+    # for slicing.
     if convert_to_numpy:
         data = jax.tree.map(
-            lambda x, a: x if a is None else np.array(x),
+            lambda x, spec: x
+            if (spec is None or isinstance(spec, str))
+            else np.array(x),
             data,
-            batch_axes,
-            is_leaf=lambda x: x is None,
+            resolved_axes,
+            is_leaf=_is_leaf,
         )
 
     # Reduce batch size if the dataset has less examples than batch size
@@ -183,10 +310,10 @@ def batch_data[T](
         while end <= dataset_size:
             batch_perm = perm[start:end]
             yield jax.tree.map(
-                lambda a, x: x if a is None else x[batch_perm],
-                batch_axes,
+                lambda leaf, spec: _leaf_take(leaf, spec, batch_perm),
                 data,
-                is_leaf=lambda x: x is None,
+                resolved_axes,
+                is_leaf=_is_leaf,
             )
             start = end
             end = start + batch_size
@@ -195,18 +322,20 @@ def batch_data[T](
 def split_data(
     data: PyTree[Any],
     proportions: Sequence[int | float],
-    batch_axes: PyTree[int | None] = 0,
+    batch_axes: PyTree[int | str | None] = 0,
     *,
     key: PRNGKeyArray,
 ) -> tuple[PyTree[Any], ...]:
     """Split a `PyTree` of data into multiply randomly drawn subsets.
 
-    This function is useful for splitting into training and test datasets. The
-    axis of the split if controlled by the `batch_axes` argument, which
-    specifies the batch axis for each leaf in `data`.
+    This function is useful for splitting into training and test datasets.
+    The axis of the split is controlled by the `batch_axes` argument, which
+    specifies the batch axis for each leaf in `data` (positional `int` for
+    array leaves, dim-name `str` for xarray leaves, or `None` to leave a
+    leaf unsplit).
 
     Example:
-        This is an example for a nested PyTree` of data.
+        Plain-array pytree:
 
         ```python
         >>> import klax
@@ -227,13 +356,14 @@ def split_data(
 
     Args:
         data: Data that shall be split. It can be any `PyTree`.
-        proportions: Proportions of the split that will be applied to the data,
-            e.g., `(80, 20)` for a 80% to 20% split. The proportions must be
-            non-negative.
-        batch_axes: PyTree of the batch axis indices. `None` is used to
-            indicate that the corresponding leaf or subtree in data does not
-            have a batch axis. `batch_axes` must have the same structure as
-            `data` or have `data` as a prefix. (Defaults to 0)
+        proportions: Proportions of the split that will be applied to the
+            data, e.g., `(80, 20)` for a 80% to 20% split. The proportions
+            must be non-negative.
+        batch_axes: PyTree of batch-axis specifications. Each leaf is one of
+            `int` (positional axis on an array leaf), `str` (dim name on an
+            xarray leaf), or `None` (do not split this subtree). `batch_axes`
+            must have the same structure as `data` or have `data` as a
+            prefix. (Defaults to `0`.)
         key: A `jax.random.PRNGKey` used to provide randomness to the split.
             (Keyword only argument.)
 
@@ -248,7 +378,7 @@ def split_data(
         raise ValueError("Proportions must be non-negative.")
     props = props / jnp.sum(props)
 
-    batch_axes, dataset_size = broadcast_and_get_size(data, batch_axes)
+    resolved_axes, dataset_size = broadcast_and_get_size(data, batch_axes)
 
     indices = jnp.arange(dataset_size)
     perm = jr.permutation(key, indices)
@@ -263,12 +393,10 @@ def split_data(
 
     def get_subset(section):
         return jax.tree.map(
-            lambda a, d: d
-            if a is None
-            else jnp.take(d, section, axis=a, unique_indices=True),
-            batch_axes,
+            lambda leaf, spec: _leaf_take(leaf, spec, section),
             data,
-            is_leaf=lambda x: x is None,
+            resolved_axes,
+            is_leaf=_is_leaf,
         )
 
     return tuple(get_subset(section) for section in sections)

--- a/klax/_logging.py
+++ b/klax/_logging.py
@@ -31,10 +31,10 @@ from klax._trainstate import TrainingContext
 try:
     from tqdm.auto import tqdm
 
-    _TQDM_AVAILABLE = True
+    _HAS_TQDM = True
 except ImportError:
-    tqdm = None
-    _TQDM_AVAILABLE = False
+    tqdm = None  # type: ignore[assignment]
+    _HAS_TQDM = False
 
 
 class Metric(Protocol):
@@ -94,7 +94,7 @@ class BatchMetric:
         data: PyTree[Any, "T"],
         batcher: Batcher,
         batch_size: int,
-        batch_axes: PyTree[int | None, "T ..."] = 0,  # type: ignore
+        batch_axes: PyTree[int | str | None, "T ..."] = 0,  # type: ignore
         verbose: bool = False,
         jit_compile: bool = True,
         *,
@@ -119,6 +119,7 @@ class BatchMetric:
         self.verbose = verbose
         self.batch_generator = batcher(data, batch_size, batch_axes, key=key)
         self.func = eqx.filter_jit(func) if jit_compile else func
+        # self.func = jax.jit(func) if jit_compile else func
 
     def __call__(self, context: TrainingContext) -> Any:
         """Compute the metric.
@@ -333,9 +334,10 @@ class MetricLogger(Callback):
         self.log_every = log_every
         self.history = History() if history is None else history
         self.verbose = verbose
-        if (verbose == 2) and not _TQDM_AVAILABLE:
+        if (verbose == 2) and not _HAS_TQDM:
             print(
-                "Warning: tqdm for progress bar not installed. Changing verbosity level to 1."
+                "Warning: tqdm for progress bar not installed. "
+                "Changing verbosity level to 1."
             )
             self.verbose = 1
 

--- a/klax/_training.py
+++ b/klax/_training.py
@@ -115,7 +115,7 @@ def fit[T: eqx.Module](
     data: PyTree[Any],
     *,
     batch_size: int = 32,
-    batch_axes: PyTree[int | None] = 0,
+    batch_axes: PyTree[int | str | None] = 0,
     run_state: PyTree[Any] = None,
     validation_data: PyTree[Any] = None,
     steps: int = 1000,
@@ -145,11 +145,14 @@ def fit[T: eqx.Module](
             tuple `(x, y)` with model inputs `x` and model outputs `y`.
         batch_size: The number of examples in a batch.
         batch_axes: A `PyTree` denoting, which axis is the batch axis for
-            arrays in `data`. `batch_axes` must be a prefix of `data`. By
-            specifying `batch_axes` as a `PyTree` it is possible to specify
-            different batch axes for different leaves of `data`. (Defaults to
-            `0`, meaning the first axes of arrays in `data` are batch
-            dimensions.)
+            arrays in `data`. Each leaf is one of `int` (positional axis on
+            an array leaf), `str` (dim name on an `xarray` leaf), or `None`
+            (the corresponding subtree is not batched). `batch_axes` must
+            be a prefix of `data`. By specifying `batch_axes` as a `PyTree`
+            it is possible to specify different batch axes for different
+            leaves of `data`. (Defaults to `0`, meaning the first axes of
+            arrays in `data` are batch dimensions. xarray leaves require
+            an explicit `str` dim name.)
 
             Example: For a dataset of 100 examples `data = (x, (y1, y2), "some_string")`
             where `x` has  shape `(100, 32)`, `y1` has shape `(100,)`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,11 @@ dev = [
     "pre-commit>=4.2.0",
     "pytest>=8.3.5",
     "ruff>=0.11.10",
+    "ty>=0.0.53",
+]
+xarray-experimental = [
+    "gdm-xarray-jax",
+    "xarray>=2026.4.0",
 ]
 
 [tool.hatch.build.targets.wheel]
@@ -94,3 +99,6 @@ ignore = [
     "E741",
     "UP038",
 ]
+
+[tool.uv.sources]
+gdm-xarray-jax = { git = "https://github.com/google-deepmind/xarray_jax.git", rev = "v0.1.1" }

--- a/tests/test_datahandler.py
+++ b/tests/test_datahandler.py
@@ -107,3 +107,145 @@ class TestSplitData:
         data = np.arange(10)
         with pytest.raises(ValueError):
             klax.split_data(data, (-1.0,), key=getkey())
+
+
+xr = pytest.importorskip("xarray")
+
+
+class TestBatchDataXArray:
+    def _dataset(self, key, n_batch=100, n_features=4):
+        import jax.numpy as jnp
+
+        return xr.Dataset(
+            {
+                "y": (
+                    ("batch", "i"),
+                    jrandom.uniform(key, (n_batch, n_features)),
+                ),
+                "label": (("batch",), ["text"] * n_batch),
+            },
+            coords={"batch": jnp.arange(n_batch), "i": jnp.arange(n_features)},
+        )
+
+    def test_dataset_with_str_axis(self, getkey):
+        data = self._dataset(getkey())
+        generator = klax.batch_data(
+            data, batch_size=10, batch_axes="batch", key=getkey()
+        )
+        batch = next(generator)
+        assert isinstance(batch, xr.Dataset)
+        assert batch.sizes["batch"] == 10
+        assert batch.sizes["i"] == 4
+        assert "batch" in batch.coords and "i" in batch.coords
+        assert batch.coords["i"].size == 4
+
+    def test_dataarray_with_str_axis(self, getkey):
+        ds = self._dataset(getkey())
+        data = ds["y"]
+        generator = klax.batch_data(
+            data, batch_size=8, batch_axes="batch", key=getkey()
+        )
+        batch = next(generator)
+        assert isinstance(batch, xr.DataArray)
+        assert batch.sizes["batch"] == 8
+        assert batch.sizes["i"] == 4
+
+    def test_mixed_pytree(self, getkey):
+        ds = self._dataset(getkey())
+        arr = jrandom.uniform(getkey(), (100, 3))
+        data = {"x": arr, "y": ds}
+        batch_axes = {"x": 0, "y": "batch"}
+        generator = klax.batch_data(
+            data, batch_size=10, batch_axes=batch_axes, key=getkey()
+        )
+        batch = next(generator)
+        assert batch["x"].shape[0] == 10
+        assert batch["y"].sizes["batch"] == 10
+
+    def test_int_spec_on_xarray_raises(self, getkey):
+        data = self._dataset(getkey())
+        gen = klax.batch_data(data, batch_size=10, key=getkey())
+        with pytest.raises(TypeError, match="must be a `str` dim name"):
+            next(gen)
+
+    def test_str_spec_on_array_raises(self, getkey):
+        data = jrandom.uniform(getkey(), (10, 4))
+        gen = klax.batch_data(
+            data, batch_size=4, batch_axes="batch", key=getkey()
+        )
+        with pytest.raises(TypeError, match="only valid for xarray leaves"):
+            next(gen)
+
+    def test_unknown_dim_raises(self, getkey):
+        data = self._dataset(getkey())
+        gen = klax.batch_data(
+            data, batch_size=10, batch_axes="missing", key=getkey()
+        )
+        with pytest.raises(ValueError, match="not present on xarray leaf"):
+            next(gen)
+
+    def test_none_passthrough_for_xarray(self, getkey):
+        ds = self._dataset(getkey())
+        arr = jrandom.uniform(getkey(), (100, 3))
+        data = {"x": arr, "y": ds}
+        batch_axes = {"x": 0, "y": None}
+        generator = klax.batch_data(
+            data, batch_size=10, batch_axes=batch_axes, key=getkey()
+        )
+        batch = next(generator)
+        assert batch["x"].shape[0] == 10
+        # y was not batched: same sizes as the original dataset
+        assert batch["y"].sizes["batch"] == 100
+
+    def test_convert_to_numpy_skips_xarray(self, getkey):
+        ds = self._dataset(getkey())
+        generator = klax.batch_data(
+            ds,
+            batch_size=10,
+            batch_axes="batch",
+            convert_to_numpy=True,
+            key=getkey(),
+        )
+        batch = next(generator)
+        assert isinstance(batch, xr.Dataset)
+
+
+class TestSplitDataXArray:
+    def _dataset(self, key, n_batch=20, n_features=2):
+        import jax.numpy as jnp
+
+        return xr.Dataset(
+            {
+                "y": (
+                    ("batch", "i"),
+                    jrandom.uniform(key, (n_batch, n_features)),
+                ),
+                "label": (("batch",), ["text"] * n_batch),
+            },
+            coords={"batch": jnp.arange(n_batch), "i": jnp.arange(n_features)},
+        )
+
+    def test_split_dataset(self, getkey):
+        n_batch = 20
+        data = self._dataset(getkey(), n_batch=n_batch)
+        s1, s2 = klax.split_data(
+            data, (3, 1), batch_axes="batch", key=getkey()
+        )
+        assert isinstance(s1, xr.Dataset) and isinstance(s2, xr.Dataset)
+        assert s1.sizes["batch"] + s2.sizes["batch"] == n_batch
+        assert s1.sizes["batch"] == 15 and s2.sizes["batch"] == 5
+        assert s1.sizes["i"] == 2 and s2.sizes["i"] == 2
+
+    def test_split_mixed(self, getkey):
+        n_batch = 20
+        ds = self._dataset(getkey(), n_batch=n_batch)
+        arr = jrandom.uniform(getkey(), (n_batch, 5))
+        data = {"x": arr, "y": ds}
+        batch_axes = {"x": 0, "y": "batch"}
+        s1, s2 = klax.split_data(
+            data, (1, 1), batch_axes=batch_axes, key=getkey()
+        )
+        assert s1["x"].shape[0] == n_batch // 2
+        assert s2["x"].shape[0] == n_batch // 2
+        assert s1["y"].sizes["batch"] == n_batch // 2
+        assert s2["y"].sizes["batch"] == n_batch // 2

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -229,7 +229,7 @@ class TestRunTrainingLoop:
 
 
 class TestFit:
-    def test_basic_behavior(self, getkey):
+    def test_default_behavior(self, getkey):
         model = klax.nn.FICNN(2, "scalar", [4, 4], key=getkey())
 
         data = (
@@ -244,6 +244,51 @@ class TestFit:
             batch_axes=0,
             steps=5,
             loss=klax.mse,
+            optimizer=optax.sgd(0.1),
+            key=getkey(),
+        )
+
+        assert isinstance(trained_model, klax.nn.FICNN)
+        assert history.total_steps == 5
+        assert "loss" in history.content
+        loss_steps, loss_values = history["loss"]
+        assert loss_steps == [0]
+        assert len(loss_values) == 1
+
+    def test_default_behavior_with_xarray(self, getkey):
+        xr = pytest.importorskip(
+            "xarray", reason="xarray dependency is not installed"
+        )
+        # xarray_jax registers xr.Dataset/DataArray as JAX pytrees, which is
+        # required for `eqx.filter_jit` to flatten an xarray batch into array
+        # leaves instead of trying to hash the whole Dataset as a static arg.
+        pytest.importorskip(
+            "xarray_jax", reason="xarray_jax dependency is not installed"
+        )
+
+        model = klax.nn.FICNN(2, "scalar", [4, 4], key=getkey())
+
+        class MyLoss(klax.Loss):
+            def value(self, model, batch, run_state):
+                y_pred = jax.vmap(model)(batch.x.data)
+                return jnp.mean((batch.y.data - y_pred) ** 2)
+
+        data = xr.Dataset(
+            {
+                "x": (("batch", "i"), jr.uniform(getkey(), (100, 2))),
+                "y": (("batch",), jr.uniform(getkey(), (100,))),
+            },
+            coords={"batch": jnp.arange(100), "i": jnp.arange(2)},
+        )
+        print(data)
+
+        trained_model, history = klax.fit(
+            model,
+            data,
+            batch_size=5,
+            batch_axes="batch",
+            steps=5,
+            loss=MyLoss(),
             optimizer=optax.sgd(0.1),
             key=getkey(),
         )


### PR DESCRIPTION
`klax.batch_data` and `klax.split_data` previously crashed on `xr.Dataset`
and `xr.DataArray` inputs because the broadcast in `broadcast_and_get_size`
tried to rebuild an xarray container with integer leaves, violating xarray's dim/coord invariants.

Refactor the data handlers to treat xarray containers as opaque leaves and
dispatch slicing by leaf type. `batch_axes` leaves now accept `int | str |
None`: `int` is a positional axis on an array leaf, `str` is a dim name on
an xarray leaf, `None` skips a subtree. A `str` spec on a non-xarray leaf
and an `int` spec on an xarray leaf both raise a `TypeError` with the available alternatives spelled out.

xarray is an optional dependency. `klax._datahandler` imports it behind a
`_HAS_XARRAY` flag; if it is missing, the new code paths are dead and plain-pytree batching behaves exactly as before. A new `xarray-experimental` extra wires up `xarray` and `gdm-xarray-jax` for users who want named-dim batching (and `xarray_jax`-backed pytree registration when JIT'ing a loss that takes xarray batches).

- klax/_datahandler.py: add `_is_xarray`, `_is_leaf`, `_normalize_one`, `_broadcast_spec`, `_leaf_size`, `_leaf_take`; rewrite `broadcast_and_get_size`, `batch_data`, `split_data` around them; widen
  the `Batcher` Protocol; update docstrings with xarray examples.
- klax/_training.py, klax/_logging.py: widen `batch_axes` type annotation
  to `PyTree[int | str | None]` and update the `fit` docstring.
- pyproject.toml: add `xarray-experimental` extra (xarray + gdm-xarray-jax
  pinned via uv source to the upstream tag).
- tests/test_datahandler.py: add `TestBatchDataXArray` and `TestSplitDataXArray` (Dataset, DataArray, mixed pytrees, None passthrough, error cases) gated on `pytest.importorskip("xarray")`.
- tests/test_training.py: add `test_default_behavior_with_xarray` end-to-end
  with `xarray_jax` registration.